### PR TITLE
FLIP algorithm

### DIFF
--- a/src/input.f90
+++ b/src/input.f90
@@ -23,6 +23,10 @@ character(16) :: boundary_left = 'mirror', boundary_right = 'mirror'
 ! optional analytic reference solution
 character(16) :: analytic_reference = 'none'
 
+! optional solver option for pn solver
+! right now, just chooses iteration order either classical "flip" or my version of "lupine"
+character(16) :: pn_solver_opt = 'lupine'
+
 public :: input_read, input_cleanup
 
 public :: nx, dx, xslib_fname, mat_map
@@ -31,6 +35,7 @@ public :: pnorder
 public :: refine
 public :: boundary_left, boundary_right
 public :: analytic_reference
+public :: pn_solver_opt
 
 contains
 
@@ -93,6 +98,8 @@ contains
           read(line, *) card, boundary_right
         case ('analytic_reference')
           read(line, *) card, analytic_reference
+        case ('pn_solver_opt')
+          read(line, *) card, pn_solver_opt
         case default
           write(*,*) 'card:', trim(adjustl(card))
           stop 'unknown input card'

--- a/src/main.f90
+++ b/src/main.f90
@@ -6,7 +6,7 @@ use input, only : input_read, input_cleanup, &
   k_tol, phi_tol, max_iter, analytic_reference
 use geometry, only : geometry_uniform_refinement, geometry_summary
 use diffusion, only : diffusion_power_iteration
-use transport, only : sigma_tr, transport_power_iteration
+use transport, only : sigma_tr, transport_power_iteration_flip
 use output, only : output_open_file, output_close_file, output_write, &
   output_flux_csv, output_power_csv, output_phi_csv, output_transportxs_csv
 use power, only : power_calculate
@@ -66,7 +66,7 @@ allocate(phi(nx, xs%ngroup, pnorder+1))
 if (pnorder == 0) then
   call diffusion_power_iteration(nx, dx, mat_map, xs, boundary_right, k_tol, phi_tol, max_iter, keff, phi(:,:,1))
 else
-  call transport_power_iteration(nx, dx, mat_map, xs, boundary_right, k_tol, phi_tol, max_iter, pnorder, keff, phi)
+  call transport_power_iteration_flip(nx, dx, mat_map, xs, boundary_right, k_tol, phi_tol, max_iter, pnorder, keff, phi)
 endif
 
 write(line, '(a,f22.20)') 'keff = ', keff

--- a/src/main.f90
+++ b/src/main.f90
@@ -3,10 +3,10 @@ use kind
 use xs, only : XSLibrary, xs_read_library, xs_cleanup
 use input, only : input_read, input_cleanup, &
   xslib_fname, refine, nx, dx, mat_map, pnorder, boundary_right, &
-  k_tol, phi_tol, max_iter, analytic_reference
+  k_tol, phi_tol, max_iter, analytic_reference, pn_solver_opt
 use geometry, only : geometry_uniform_refinement, geometry_summary
 use diffusion, only : diffusion_power_iteration
-use transport, only : sigma_tr, transport_power_iteration_flip
+use transport, only : sigma_tr, transport_power_iteration, transport_power_iteration_flip
 use output, only : output_open_file, output_close_file, output_write, &
   output_flux_csv, output_power_csv, output_phi_csv, output_transportxs_csv
 use power, only : power_calculate
@@ -66,7 +66,11 @@ allocate(phi(nx, xs%ngroup, pnorder+1))
 if (pnorder == 0) then
   call diffusion_power_iteration(nx, dx, mat_map, xs, boundary_right, k_tol, phi_tol, max_iter, keff, phi(:,:,1))
 else
-  call transport_power_iteration_flip(nx, dx, mat_map, xs, boundary_right, k_tol, phi_tol, max_iter, pnorder, keff, phi)
+  if (pn_solver_opt == 'flip') then
+    call transport_power_iteration_flip(nx, dx, mat_map, xs, boundary_right, k_tol, phi_tol, max_iter, abs(pnorder), keff, phi)
+  elseif (pn_solver_opt == 'lupine') then
+    call transport_power_iteration(nx, dx, mat_map, xs, boundary_right, k_tol, phi_tol, max_iter, pnorder, keff, phi)
+  endif
 endif
 
 write(line, '(a,f22.20)') 'keff = ', keff

--- a/src/transport.f90
+++ b/src/transport.f90
@@ -303,7 +303,7 @@ contains
     type(XSLibrary), intent(in) :: xslib
     real(rk), intent(in) :: phi(:,:,:) ! (nx, ngroup, pnorder)
     integer(ik), intent(in) :: idxn
-    real(rk), intent(out) :: qup(:,:) ! (nx, ngroup) 
+    real(rk), intent(out) :: qup(:,:) ! (nx, ngroup)
 
     integer(ik) :: i, g
     integer(ik) :: mthis
@@ -330,7 +330,7 @@ contains
     real(rk), intent(in) :: phi(:,:,:) ! (nx, ngroup, pnorder)
     integer(ik), intent(in) :: idxn
     integer(ik), intent(in) :: g
-    real(rk), intent(out) :: qdown(:) ! (nx) 
+    real(rk), intent(out) :: qdown(:) ! (nx)
 
     integer(ik) :: i
     integer(ik) :: mthis
@@ -526,7 +526,7 @@ contains
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     type(XSLibrary), intent(in) :: xslib
     character(*), intent(in) :: boundary_right
-    real(rk), intent(in) :: k_tol, phi_tol 
+    real(rk), intent(in) :: k_tol, phi_tol
     integer(ik), intent(in) :: max_iter
     integer(ik), intent(in) :: pnorder
     real(rk), intent(inout) :: keff
@@ -594,6 +594,7 @@ contains
       phi_old = phi
       fsum_old = fsum
 
+      ! update odd moments -> use odd moments for transport xs -> reconstruct transport matrices
       call transport_odd_update(nx, dx, xslib%ngroup, boundary_right, pnorder, sigma_tr, phi)
       call transport_build_transportxs(nx, mat_map, xslib, pnorder, phi, sigma_tr)
       call transport_build_matrix(nx, dx, mat_map, xslib, boundary_right, neven, sub, dia, sup)
@@ -662,7 +663,7 @@ contains
       endif
 
     enddo ! iter = 1,max_iter
-    
+
     if (iter > max_iter) then
       call output_write('WARNING: failed to converge')
     endif


### PR DESCRIPTION
Some older literature suggests iterating over all moments within a group and then moving to the next group.

While it is occasionally written that this is what was used in the FLIP code, that is not possible. FLIP was a one-speed calculation.

Consider implementing, it may help with stability.