### PR TITLE
Transport block fixedsrc

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -61,5 +61,5 @@ output.o : fileio.o kind.o
 power.o : kind.o xs.o
 timer.o : kind.o output.o
 transport.o : exception_handler.o kind.o linalg.o numeric.o output.o timer.o xs.o
-transport_block.o : exception_handler.o kind.o linalg.o numeric.o output.o timer.o xs.o
+transport_block.o : constant.o exception_handler.o kind.o linalg.o numeric.o output.o timer.o xs.o
 xs.o : exception_handler.o fileio.o kind.o linalg.o output.o

--- a/src/diffusion.f90
+++ b/src/diffusion.f90
@@ -239,6 +239,8 @@ contains
 
     character(1024) :: line
 
+    logical, parameter :: matrix_dump = .true.
+
     allocate(sub(nx-1,xslib%ngroup), dia(nx,xslib%ngroup), sup(nx-1,xslib%ngroup))
     allocate(sub_copy(nx-1), dia_copy(nx), sup_copy(nx-1))
 
@@ -252,7 +254,7 @@ contains
       call diffusion_build_matrix(nx, dx, mat_map, xslib, boundary_right, sub, dia, sup, diffusion_coeff)
     else
       call diffusion_build_matrix(nx, dx, mat_map, xslib, boundary_right, sub, dia, sup)
-      if (.false.) then
+      if (matrix_dump) then
         write(730, '(es13.6,",",es13.6,",",es13.6)') 0d0 , dia(1,1), sup(1,1)
         do i = 2,nx-1
           write(730, '(es13.6,",",es13.6,",",es13.6)') sub(i-1,1), dia(i,1), sup(i,1)

--- a/src/diffusion.f90
+++ b/src/diffusion.f90
@@ -239,7 +239,7 @@ contains
 
     character(1024) :: line
 
-    logical, parameter :: matrix_dump = .true.
+    logical, parameter :: matrix_dump = .false.
 
     allocate(sub(nx-1,xslib%ngroup), dia(nx,xslib%ngroup), sup(nx-1,xslib%ngroup))
     allocate(sub_copy(nx-1), dia_copy(nx), sup_copy(nx-1))

--- a/src/input.f90
+++ b/src/input.f90
@@ -37,6 +37,9 @@ logical :: high_low = .false.
 ! optional recalculate diffusion coefficient to 1/(3*sigma_t) for consistency with P1
 logical :: force_consistent_diffusion = .false.
 
+! optional calculation type. either 'eigenvalue' or 'fixed_source'
+character(16) :: calc_type = 'eigenvalue'
+
 public :: input_read, input_cleanup
 
 public :: nx, dx, xslib_fname, mat_map
@@ -48,6 +51,7 @@ public :: analytic_reference
 public :: pn_solver_opt
 public :: energy_solver_opt
 public :: high_low, force_consistent_diffusion
+public :: calc_type
 
 contains
 
@@ -119,6 +123,8 @@ contains
           read(line, *) card, high_low
         case ('force_consistent_diffusion')
           read(line, *) card, force_consistent_diffusion
+        case ('calc_type')
+          read(line, *) card, calc_type
         case default
           call exception_fatal('unknown input card: ' // trim(adjustl(card)))
       endselect
@@ -170,6 +176,7 @@ contains
     call output_write(line)
     write(line, '(a,l2)') 'force_consistent_diffusion = ', force_consistent_diffusion
     call output_write(line)
+    call output_write('calc_type = *' // trim(adjustl(calc_type)) // '*')
 
     call output_write('')
   endsubroutine input_summary

--- a/src/main.f90
+++ b/src/main.f90
@@ -4,7 +4,7 @@ use xs, only : XSLibrary, XSMaterial, xs_read_library, xs_cleanup
 use input, only : input_read, input_cleanup, &
   xslib_fname, refine, nx, dx, mat_map, pnorder, boundary_right, &
   k_tol, phi_tol, max_iter, analytic_reference, pn_solver_opt, energy_solver_opt, &
-  high_low, force_consistent_diffusion
+  high_low, force_consistent_diffusion, calc_type
 use geometry, only : geometry_uniform_refinement, geometry_summary
 use diffusion, only : diffusion_power_iteration
 use diffusion_block, only : diffusion_block_power_iteration
@@ -108,7 +108,7 @@ else
   select case (energy_solver_opt)
     case ('block')
       call transport_block_power_iteration( &
-        nx, dx, mat_map, xs, boundary_right, k_tol, phi_tol, max_iter, pnorder, &
+        nx, dx, mat_map, xs, boundary_right, calc_type, k_tol, phi_tol, max_iter, pnorder, &
         keff, sigma_tr, phi)
       if (high_low) then
         call diffusion_power_iteration( &

--- a/src/transport_block.f90
+++ b/src/transport_block.f90
@@ -510,7 +510,7 @@ contains
   endfunction transport_block_fission_summation
 
   subroutine transport_block_power_iteration(&
-    nx, dx, mat_map, xslib, boundary_right, k_tol, phi_tol, max_iter, pnorder, keff, sigma_tr, phi)
+    nx, dx, mat_map, xslib, boundary_right, calc_type, k_tol, phi_tol, max_iter, pnorder, keff, sigma_tr, phi)
     use xs, only : XSLibrary
     use linalg, only : trid_block
     use output, only : output_write
@@ -521,6 +521,7 @@ contains
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     type(XSLibrary), intent(in) :: xslib
     character(*), intent(in) :: boundary_right
+    character(*), intent(in) :: calc_type
     real(rk), intent(in) :: k_tol, phi_tol
     integer(ik), intent(in) :: max_iter
     integer(ik), intent(in) :: pnorder
@@ -548,8 +549,6 @@ contains
     real(rk), allocatable :: phi_block(:,:,:), phi_old(:,:,:) ! (ngroup,nx,pnorder+1)
 
     character(1024) :: line
-
-    character(*), parameter :: calc_type = 'fixed_source'
 
     if (mod(pnorder,2) /= 1) then
       call exception_fatal('pnorder must be odd')

--- a/src/transport_block.f90
+++ b/src/transport_block.f90
@@ -549,6 +549,8 @@ contains
 
     character(1024) :: line
 
+    character(*), parameter :: calc_type = 'fixed_source'
+
     if (mod(pnorder,2) /= 1) then
       call exception_fatal('pnorder must be odd')
     endif
@@ -590,6 +592,14 @@ contains
     call transport_block_build_matrix(nx, dx, mat_map, xslib, boundary_right, neven, sub, dia, sup)
     call timer_stop('transport_build_matrix')
 
+    if (calc_type == 'fixed_source') then
+      call output_write('  building fixed source')
+      call output_write('  using fission spectrum for fixed source specturm: ' // trim(adjustl(xslib%mat(1)%name)))
+      call timer_start('transport_fixed_source')
+      call transport_block_build_fixed_source(nx, dx, xslib%mat(1)%chi, fsource)
+      call timer_stop('transport_fixed_source')
+    endif
+
     call output_write('  beginning iterations')
     do iter = 1,max_iter
 
@@ -609,10 +619,16 @@ contains
         q = pn_next_source(:,:,n)
 
         if (n == 1) then
-          call timer_start('transport_fsource')
-          call transport_block_build_fsource(nx, dx, mat_map, xslib, phi_block(:,:,1), fsource)
-          q = q + fsource / keff
-          call timer_stop('transport_fsource')
+          if (calc_type == 'eigenvalue') then
+            call timer_start('transport_fsource')
+            call transport_block_build_fsource(nx, dx, mat_map, xslib, phi_block(:,:,1), fsource)
+            q = q + fsource / keff
+            call timer_stop('transport_fsource')
+          else if (calc_type == 'fixed_source') then
+            q = q + fsource
+          else
+            call exception_fatal('unknown calc_type: ' // trim(adjustl(calc_type)))
+          endif
         else
           call timer_start('transport_pn_source')
           call transport_block_build_prev_source( &
@@ -631,8 +647,10 @@ contains
       enddo ! n = 1,neven
 
       call timer_start('transport_convergence')
-      fsum = transport_block_fission_summation(nx, dx, mat_map, xslib, phi_block(:,:,1))
-      if (iter > 1) keff = keff * fsum / fsum_old
+      if (calc_type == 'eigenvalue') then
+        fsum = transport_block_fission_summation(nx, dx, mat_map, xslib, phi_block(:,:,1))
+        if (iter > 1) keff = keff * fsum / fsum_old
+      endif
       delta_k = abs(keff - k_old)
       delta_phi = maxval(abs(phi_block - phi_old)) / maxval(phi_block)
       call timer_stop('transport_convergence')
@@ -817,96 +835,10 @@ contains
     enddo ! n = 1,pnorder+1
   endsubroutine transport_block_calc_transportxs
 
-  subroutine transport_block_fixed_source(&
-    nx, dx, mat_map, xslib, boundary_right, k_tol, phi_tol, max_iter, pnorder, keff, sigma_tr, phi)
-    use xs, only : XSLibrary
-    use linalg, only : trid
-    use output, only : output_write
-    use timer, only : timer_start, timer_stop
-    use exception_handler, only : exception_fatal, exception_warning
-    integer(ik), intent(in) :: nx
-    real(rk), intent(in) :: dx(:) ! (nx)
-    integer(ik), intent(in) :: mat_map(:) ! (nx)
-    type(XSLibrary), intent(in) :: xslib
-    character(*), intent(in) :: boundary_right
-    real(rk), intent(in) :: k_tol
-    real(rk), intent(in) :: phi_tol
-    integer(ik), intent(in) :: max_iter
-    integer(ik), intent(in) :: pnorder
-    real(rk), intent(out) :: keff
-    real(rk), intent(out) :: sigma_tr ! (nx,ngroup,nmoment)
-    real(rk), intent(out) :: phi(:,:,:) ! (nx,ngroup,nmoment)
-
-    integer(ik) :: i, g, n
-    integer(ik) :: neven, idxn
-    integer(ik) :: iter
-
-    real(rk) :: delta_phi
-
-    ! (ngroup,ngroup,nx-1,neven) , (ngroup,ngroup,nx,neven) , (ngroup,ngroup,nx-1,neven)
-    real(rk), allocatable :: sub(:,:,:,:), dia(:,:,:,:), sup(:,:,:,:)
-    ! (ngroup,ngroup,nx-1) , (ngroup,ngroup,nx) , (ngroup,ngroup,nx-1)
-    real(rk), allocatable :: sub_copy(:,:,:), dia_copy(:,:,:), sup_copy(:,:,:)
-
-    real(rk), allocatable :: qfixed(:,:) ! (ngroup,nx)
-    real(rk), allocatable :: pn_prev_source(:,:) ! (ngroup,nx) -- for this moment
-    real(rk), allocatable :: pn_next_source(:,:,:) ! (ngroup,nx,neven) -- for all moments
-    real(rk), allocatable :: q(:,:) ! (ngroup,nx)
-
-    real(rk), allocatable :: phi_block(:,:,:), phi_old(:,:,:) ! (ngroup,nx,pnorder+1)
-
-    character(1024) :: line
-
-    if (mod(pnorder,2) /= 1) then
-      call exception_fatal('pnorder must be odd (fixed_source)')
-    endif
-    neven = (pnorder+1)/2
-
-    allocate(sub(xslib%ngroup,xslib%ngroup,nx-1,neven),&
-      dia(xslib%ngroup,xslib%ngroup,nx,neven),&
-      sup(xslib%ngroup,xslib%ngroup,nx-1,neven))
-    allocate(sub_copy(xslib%ngroup,xslib%ngroup,nx-1),&
-      dia_copy(xslib%ngroup,xslib%ngroup,nx),&
-      sup_copy(xslib%ngroup,xslib%ngroup,nx-1))
-
-    allocate(qfixed(xslib%ngroup,nx))
-    allocate(pn_prev_source(xslib%ngroup,nx))
-    allocate(pn_next_source(xslib%ngroup,nx,neven))
-    allocate(q(xslib%ngroup,nx))
-
-    allocate(phi_block(xslib%ngroup,nx,pnorder+1))
-    allocate(phi_old(xslib%ngroup,nx,pnorder+1))
-
-    phi_block(:,:,1) = 1.0_rk
-    phi_block(:,:,2:pnorder+1) = 0.0_rk
-
-    keff = 1.0_rk
-
-    call output_write('=== PN TRANSPORT BLOCK FIXED SOURCE ===')
-
-    call output_write('  building transport matrix')
-    call timer_start('transport_build_matrix')
-    call transport_block_build_matrix(nx, dx, mat_map, xslib, boundary_right, neven, sub, dia, sup)
-    call timer_stop('transport_build_matrix')
-
-    call output_write('  building fixed source')
-    call timer_start('transport_build_fixed_source')
-    call transport_block_build_fixed_source(nx, dx, xslib%ngroup, xslib%mat(1)%chi, qfixed)
-    call timer_stop('transport_build_fixed_source')
-
-    call output_write('  beginning iterations')
-
-    deallocate(qfixed, pn_prev_source, pn_next_source, q)
-    deallocate(phi_block, phi_old)
-    deallocate(sub, dia, sup)
-    deallocate(sub_copy, dia_copy, sup_copy)
-  endsubroutine transport_block_fixed_source
-
-  subroutine transport_block_build_fixed_source(nx, dx, ngroup, chi, qfixed)
+  subroutine transport_block_build_fixed_source(nx, dx, chi, qfixed)
     use constant, only : pi
     integer(ik), intent(in) :: nx
     real(rk), intent(in) :: dx(:) ! (nx)
-    integer(ik), intent(in) :: ngroup
     real(rk), intent(in) :: chi(:) ! (ngroup)
     real(rk), intent(out) :: qfixed(:,:) ! (ngroup,nx)
     

--- a/tools/transport_ratio.py
+++ b/tools/transport_ratio.py
@@ -1,0 +1,70 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import sys
+
+import plot_settings
+import transportxs_plot
+import xslib
+from ebound import c5_586
+
+if __name__ == "__main__":
+
+    extension = "png"
+    resolution = 600
+
+    fname = sys.argv[1]
+
+    x, sigma_tr = transportxs_plot.load(fname)
+
+    dx = np.zeros_like(x)
+    xleft = 0.0
+    for i in range(len(dx)):
+        dx[i] = 2.0 * (x[i] - xleft)
+        xleft += dx[i]
+
+    length = np.sum(dx)
+
+    ngroup = sigma_tr.shape[1]
+    nx = sigma_tr.shape[2]
+
+    sigtr = np.zeros(ngroup)  # just first one...
+    for i in range(nx):
+        sigtr += dx[i] * sigma_tr[1, :, i]
+    sigtr /= length
+
+    c5_586_midpoint = np.zeros(ngroup)
+    for g in range(ngroup):
+        c5_586_midpoint[g] = 0.5 * (c5_586[g] + c5_586[g + 1])
+
+    xs = xslib.load("c5xs_speng.xs")
+    sigt = xs["COO_H1"]["sigma_t"].copy()
+
+    plt.figure()
+    plt.loglog(c5_586_midpoint, sigtr, "-x")
+    plt.xlabel("Energy [eV]")
+    plt.ylabel("Cross Section [barn]")
+    plt.title("Transport Cross Section")
+    plt.tight_layout()
+    plt.savefig("sigma_tr_spectrum." + extension, dpi=resolution)
+
+    plt.figure()
+    plt.loglog(c5_586_midpoint, sigt, "-x")
+    plt.xlabel("Energy [eV]")
+    plt.ylabel("Cross Section [barn]")
+    plt.title("Total Cross Section")
+    plt.tight_layout()
+    plt.savefig("sigma_t_spectrum." + extension, dpi=resolution)
+
+    sigtr_ref = np.loadtxt("/Users/williamdawn/work/siren/cases/pno.slab/sig_tr.txt")
+
+    plt.figure()
+    plt.semilogx(c5_586_midpoint, sigtr / sigt, "-x", label="Siren")
+    plt.semilogx(c5_586_midpoint, sigtr_ref / sigt, "-x", label="SPENG")
+    plt.legend()
+    plt.xlabel("Energy [eV]")
+    plt.ylabel("$\\Sigma_{tr} / \\Sigma_{t}$")
+    plt.title("Transport-to-Total Cross Section Ratio")
+    plt.tight_layout()
+    plt.savefig("sigma_tr_ratio." + extension, dpi=resolution)
+
+    plt.show()

--- a/tools/transport_ratio.py
+++ b/tools/transport_ratio.py
@@ -55,12 +55,8 @@ if __name__ == "__main__":
     plt.tight_layout()
     plt.savefig("sigma_t_spectrum." + extension, dpi=resolution)
 
-    sigtr_ref = np.loadtxt("/Users/williamdawn/work/siren/cases/pno.slab/sig_tr.txt")
-
     plt.figure()
     plt.semilogx(c5_586_midpoint, sigtr / sigt, "-x", label="Siren")
-    plt.semilogx(c5_586_midpoint, sigtr_ref / sigt, "-x", label="SPENG")
-    plt.legend()
     plt.xlabel("Energy [eV]")
     plt.ylabel("$\\Sigma_{tr} / \\Sigma_{t}$")
     plt.title("Transport-to-Total Cross Section Ratio")

--- a/tools/transportxs_plot.py
+++ b/tools/transportxs_plot.py
@@ -53,27 +53,9 @@ if __name__ == "__main__":
         if ngroup <= 10:
             plt.legend()
         plt.xlabel("x [cm]")
-        plt.ylabel("$\\Sigma_{{tr}}(x)$ (arb. units)")
-        plt.title("Siren $\\Sigma_{{tr}}$ {:d}".format(n))
+        plt.ylabel("$\\sigma_{{tr}}(x)$ [1/cm]")
+        plt.title("Siren $\\sigma_{{tr}}$ {:d}".format(n))
         plt.tight_layout()
         plt.savefig("sigma_tr_n{:d}".format(n) + extension, dpi=dpi)
-
-    for n in range(0, pnorder, 2):
-        plt.figure()
-        for g in range(ngroup):
-            xnext = (n + 1) * (n + 1) / ((2 * n + 1) * (2 * n + 3))
-            xprev = n * n / ((2 * n + 1) * (2 * n - 1))
-            if n == 0:
-                d = xnext / sigma_tr[n + 1, g, :]
-            else:
-                d = xnext / sigma_tr[n + 1, g, :] + xprev / sigma_tr[n - 1, g, :]
-            plt.plot(x, d, label="g={:d}".format(g + 1))
-        if ngroup <= 10:
-            plt.legend()
-        plt.xlabel("x [cm]")
-        plt.ylabel("$D_g(x)$")
-        plt.title("Coefficient of Diffusivity n={:d}".format(n))
-        plt.tight_layout()
-        plt.savefig("diff_n{:d}".format(n) + extension, dpi=dpi)
 
     plt.show()


### PR DESCRIPTION
Implement a very basic fixed source solver using the block-energy transport method. This is pretty restrictive at the moment and is meant to implement SPENG.