### PR TITLE
Transport cleanup

### DIFF
--- a/cases/analytic_p3/doit.py
+++ b/cases/analytic_p3/doit.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
 
         out = run(executable, fname_run)
         if "CONVERGENCE!" not in out:
-            print("failed to converge p=", p, "r=", r)
+            print("failed to converge r=", r)
             sys.exit(1)
         out = out.split("\n")
 

--- a/src/input.f90
+++ b/src/input.f90
@@ -23,10 +23,6 @@ character(16) :: boundary_left = 'mirror', boundary_right = 'mirror'
 ! optional analytic reference solution
 character(16) :: analytic_reference = 'none'
 
-! optional solver option for pn solver
-! right now, just chooses iteration order either classical "flip" or my version of "lupine"
-character(16) :: pn_solver_opt = 'lupine'
-
 ! optional solver option for diffusion solver (to be extended to pn)
 ! choose whether to solve one-group at-a-time ("onegroup") or all at once ("block")
 character(16) :: energy_solver_opt = 'onegroup'
@@ -48,7 +44,6 @@ public :: pnorder
 public :: refine
 public :: boundary_left, boundary_right
 public :: analytic_reference
-public :: pn_solver_opt
 public :: energy_solver_opt
 public :: high_low, force_consistent_diffusion
 public :: calc_type
@@ -117,8 +112,6 @@ contains
           read(line, *) card, boundary_right
         case ('analytic_reference')
           read(line, *) card, analytic_reference
-        case ('pn_solver_opt')
-          read(line, *) card, pn_solver_opt
         case ('energy_solver_opt')
           read(line, *) card, energy_solver_opt
         case ('high_low')
@@ -167,10 +160,6 @@ contains
     call output_write('boundary_left = *' // trim(adjustl(boundary_left)) // '*')
     call output_write('boundary_right = *' // trim(adjustl(boundary_right)) // '*')
     call output_write('analytic_reference = *' // trim(adjustl(analytic_reference)) // '*')
-
-    if (pnorder /= 0) then
-      call output_write('pn_solver_opt = *' // trim(adjustl(pn_solver_opt)) // '*')
-    endif
 
     call output_write('energy_solver_opt = *' // trim(adjustl(energy_solver_opt)) // '*')
 

--- a/src/main.f90
+++ b/src/main.f90
@@ -3,12 +3,12 @@ use kind, only : rk, ik
 use xs, only : XSLibrary, XSMaterial, xs_read_library, xs_cleanup
 use input, only : input_read, input_cleanup, &
   xslib_fname, refine, nx, dx, mat_map, pnorder, boundary_right, &
-  k_tol, phi_tol, max_iter, analytic_reference, pn_solver_opt, energy_solver_opt, &
+  k_tol, phi_tol, max_iter, analytic_reference, energy_solver_opt, &
   high_low, force_consistent_diffusion, calc_type
 use geometry, only : geometry_uniform_refinement, geometry_summary
 use diffusion, only : diffusion_power_iteration
 use diffusion_block, only : diffusion_block_power_iteration
-use transport, only : transport_power_iteration, transport_power_iteration_flip
+use transport, only : transport_power_iteration
 use transport_block, only : transport_block_power_iteration
 use output, only : output_open_file, output_close_file, output_write, &
   output_flux_csv, output_power_csv, output_phi_csv, output_transportxs_csv, output_matmap_csv
@@ -116,18 +116,9 @@ else
           transportxs = sigma_tr(:,:,2))
       endif
     case ('onegroup')
-      select case (pn_solver_opt)
-        case ('flip')
-          call transport_power_iteration_flip( &
-            nx, dx, mat_map, xs, boundary_right, k_tol, phi_tol, max_iter, pnorder, &
-            keff, sigma_tr, phi)
-        case ('lupine')
-          call transport_power_iteration(&
-            nx, dx, mat_map, xs, boundary_right, k_tol, phi_tol, max_iter, pnorder, &
-            keff, sigma_tr, phi)
-        case default
-          call exception_fatal('unknown pn_solver_opt: ' // trim(adjustl(pn_solver_opt)))
-      endselect
+      call transport_power_iteration(&
+        nx, dx, mat_map, xs, boundary_right, k_tol, phi_tol, max_iter, pnorder, &
+        keff, sigma_tr, phi)
     case default
       call exception_fatal('unknown energy_solver_opt: ' // trim(adjustl(energy_solver_opt)))
   endselect

--- a/src/main.f90
+++ b/src/main.f90
@@ -69,7 +69,7 @@ call timer_start('xs_read')
 call xs_read_library(xslib_fname, xs)
 call timer_stop('xs_read')
 
-if ((pnorder /= 0) .and. (xs%nmoment /= 1) .and. (trim(adjustl(energy_solver_opt)) /= 'block')) then
+if ((pnorder /= 0) .and. (xs%nmoment /= 1) .and. (xs%ngroup > 1) .and. (trim(adjustl(energy_solver_opt)) /= 'block')) then
   call exception_fatal(&
     'The onegroup PN solver is unstable for true anisotropic scattering. ' // &
     'You must use "energy_solver_opt block"')

--- a/src/transport.f90
+++ b/src/transport.f90
@@ -4,7 +4,7 @@ implicit none
 
 private
 
-public :: transport_power_iteration, transport_power_iteration_flip
+public :: transport_power_iteration
 
 contains
 
@@ -332,37 +332,6 @@ contains
     enddo ! n = 2,pnorder+1,2
   endsubroutine transport_odd_update
 
-  subroutine transport_build_upscatter_flip(nx, dx, mat_map, xslib, phi, neven, qup)
-    use xs, only : XSLibrary
-    integer(ik), intent(in) :: nx
-    real(rk), intent(in) :: dx(:) ! (nx)
-    integer(ik), intent(in) :: mat_map(:) ! (nx)
-    type(XSLibrary), intent(in) :: xslib
-    real(rk), intent(in) :: phi(:,:,:) ! (nx, ngroup, pnorder)
-    integer(ik), intent(in) :: neven
-    real(rk), intent(out) :: qup(:,:,:) ! (nx, ngroup, neven)
-
-    integer(ik) :: i, g, n
-    integer(ik) :: idxn
-    integer(ik) :: mthis
-
-    do n = 1,neven
-      idxn = 2*(n-1)
-      if (idxn+1 > xslib%nmoment) then
-        qup(:,:,n) = 0.0_rk
-      else
-        do i = 1,nx
-          mthis = mat_map(i)
-          do g = 1,xslib%ngroup
-            qup(i,g,n) = &
-              sum(xslib%mat(mthis)%scatter(g+1:xslib%ngroup,g,idxn+1) &
-              * phi(i,g+1:xslib%ngroup,idxn+1)) * dx(i)
-          enddo
-        enddo ! i = 1,nx
-      endif
-    enddo ! n = 1,neven
-  endsubroutine transport_build_upscatter_flip
-
   subroutine transport_build_upscatter(nx, dx, mat_map, xslib, phi, idxn, qup)
     use xs, only : XSLibrary
     integer(ik), intent(in) :: nx
@@ -513,70 +482,6 @@ contains
 
   endsubroutine transport_build_next_source
 
-  subroutine transport_build_prev_source_flip(nx, dx, boundary_right, sigma_tr, phi, idxn, g, qprev)
-    use exception_handler, only : exception_fatal
-    integer(ik), intent(in) :: nx
-    real(rk), intent(in) :: dx(:) ! (nx)
-    character(*), intent(in) :: boundary_right
-    real(rk), intent(in) :: sigma_tr(:,:,:) ! (nx, ngroup, pnorder)
-    real(rk), intent(in) :: phi(:,:,:) ! (nx, ngroup, pnorder)
-    integer(ik), intent(in) :: idxn, g
-    real(rk), intent(out) :: qprev(:) ! (nx)
-
-    integer(ik) :: i
-    real(rk) :: xn, xmul
-    real(rk) :: kbprev, kbthis, kbnext
-    real(rk) :: dbprev, dbnext
-
-    xn = real(idxn, rk)
-    xmul = (xn**2-xn)/(4.0_rk*xn**2 - 1.0_rk)
-
-    ! BC at x=0, i=1
-    kbthis = xmul/sigma_tr(1,g,idxn+1-1)
-    kbnext = xmul/sigma_tr(2,g,idxn+1-1)
-    dbnext = 2 * kbthis / dx(1) * kbnext / dx(2) / (kbthis / dx(1) + kbnext / dx(2))
-    qprev(1) = -phi(1,g,idxn+1-2)*dbnext + dbnext*phi(2,g,idxn+1-2)
-
-    do i = 2,nx-1
-
-      kbprev = xmul/sigma_tr(i-1,g,idxn+1-1)
-      kbthis = xmul/sigma_tr(i  ,g,idxn+1-1)
-      kbnext = xmul/sigma_tr(i+1,g,idxn+1-1)
-
-      dbprev = 2 * kbthis / dx(i) * kbprev / dx(i-1) / (kbthis / dx(i) + kbprev / dx(i-1))
-      dbnext = 2 * kbthis / dx(i) * kbnext / dx(i+1) / (kbthis / dx(i) + kbnext / dx(i+1))
-
-      qprev(i) = &
-        phi(i-1,g,idxn+1-2) * dbprev &
-        - phi(i,g,idxn+1-2) * (dbprev + dbnext) &
-        + phi(i+1,g,idxn+1-2) * dbnext
-
-    enddo ! i = 2,nx-1
-
-    ! BC at x=L, i=N
-    select case (boundary_right)
-      case ('mirror')
-        kbprev = xmul/sigma_tr(nx-1,g,idxn+1-1)
-        kbthis = xmul/sigma_tr(nx  ,g,idxn+1-1)
-        dbprev = 2 * kbthis / dx(nx) * kbprev / dx(nx-1) / (kbthis / dx(nx) + kbprev / dx(nx-1))
-        qprev(nx) = &
-          phi(nx-1,g,idxn+1-2)*dbprev &
-          - phi(nx,g,idxn+1-2)*dbprev
-      case ('zero')
-        kbprev = xmul/sigma_tr(nx-1,g,idxn+1-1)
-        kbthis = xmul/sigma_tr(nx  ,g,idxn+1-1)
-        dbprev = 2 * kbthis / dx(nx) * kbprev / dx(nx-1) / (kbthis / dx(nx) + kbprev / dx(nx-1))
-        qprev(nx) = &
-          phi(nx-1,g,idxn+1-2)*dbprev &
-          - phi(nx,g,idxn+1-2)*dbprev &
-          - 2 * kbthis / dx(nx) * phi(nx,g,idxn+1-2)
-      case default
-        call exception_fatal( &
-          'unknown boundary in prev_source: ' // trim(adjustl(boundary_right)))
-    endselect
-
-  endsubroutine transport_build_prev_source_flip
-
   subroutine transport_build_prev_source(nx, dx, ngroup, boundary_right, sigma_tr, phi, idxn, qprev)
     use exception_handler, only : exception_fatal
     integer(ik), intent(in) :: nx
@@ -670,201 +575,6 @@ contains
 
   endfunction transport_fission_summation
 
-  subroutine transport_power_iteration_flip(&
-    nx, dx, mat_map, xslib, boundary_right, k_tol, phi_tol, max_iter, pnorder, keff, sigma_tr, phi)
-    use xs, only : XSLibrary
-    use linalg, only : trid
-    use output, only : output_write
-    use timer, only : timer_start, timer_stop
-    use exception_handler, only : exception_warning, exception_fatal
-    integer(ik), intent(in) :: nx
-    real(rk), intent(in) :: dx(:) ! (nx)
-    integer(ik), intent(in) :: mat_map(:) ! (nx)
-    type(XSLibrary), intent(in) :: xslib
-    character(*), intent(in) :: boundary_right
-    real(rk), intent(in) :: k_tol, phi_tol
-    integer(ik), intent(in) :: max_iter
-    integer(ik), intent(in) :: pnorder
-    real(rk), intent(inout) :: keff
-    real(rk), intent(inout) :: sigma_tr(:,:,:) ! (nx, ngroup, nmoment)
-    real(rk), intent(inout) :: phi(:,:,:) ! (nx, ngroup, nmoment)
-
-    ! matrix
-    real(rk), allocatable :: sub(:,:,:), dia(:,:,:), sup(:,:,:) ! (nx, ngroup, neven)
-    real(rk), allocatable :: sub_copy(:), dia_copy(:), sup_copy(:)
-    ! neutron source
-    real(rk), allocatable :: fsource(:,:) ! (nx, ngroup) -- all p0
-    real(rk), allocatable :: upsource(:,:,:) ! (nx, ngroup, neven)
-    real(rk), allocatable :: downsource(:) ! (nx) -- just this moment & this group
-    ! moment source
-    real(rk), allocatable :: pn_next_source(:,:,:) ! (nx, ngroup, neven)
-    real(rk), allocatable :: pn_prev_source(:) ! (nx) -- just this moment
-    ! combined source
-    real(rk), allocatable :: q(:)
-
-    integer(ik) :: iter
-    real(rk) :: k_old, fsum, fsum_old
-    real(rk), allocatable :: phi_old(:,:,:)
-    real(rk) :: delta_k, delta_phi
-
-    integer(ik) :: neven, idxn
-    integer(ik) :: n, g
-
-    character(1024) :: line
-
-    if (mod(pnorder,2) /= 1) then
-      call exception_fatal('pnorder must be odd')
-    endif
-
-    neven = max((pnorder + 1) / 2, 1)
-
-    allocate(sub(nx-1,xslib%ngroup,neven), dia(nx,xslib%ngroup,neven), sup(nx-1,xslib%ngroup,neven))
-    allocate(sub_copy(nx-1), dia_copy(nx), sup_copy(nx-1))
-
-    allocate(fsource(nx,xslib%ngroup))
-    allocate(upsource(nx,xslib%ngroup,neven))
-    allocate(downsource(nx))
-    allocate(pn_next_source(nx,xslib%ngroup,neven))
-    allocate(pn_prev_source(nx))
-    allocate(q(nx))
-
-    allocate(phi_old(nx,xslib%ngroup,pnorder+1))
-
-    keff = 1.0_rk
-    phi = 1.0_rk
-    fsum = 1.0_rk
-
-    call transport_init_transportxs(nx, mat_map, xslib, pnorder, sigma_tr)
-
-    call output_write('=== PN TRANSPORT POWER ITERATION (FLIP) ===')
-
-    ! I believe that the original FLIP algorithm had the nesting in the opposite order.
-    ! I think I got away with it in LUPINE since it is pretty irrelevant for isotropic scattering.
-    ! This could require somewhat intensive rewriting of routines.
-    ! See Gelbard (1959) and Fletcher (1983).
-    ! Particularly Fletcher, p. 36, bottom of column 1 and top of column 2.
-
-    do iter = 1,max_iter
-      k_old = keff
-      phi_old = phi
-      fsum_old = fsum
-
-      if (iter > 1) then
-        ! update odd moments -> use odd moments for transport xs -> reconstruct transport matrices
-        call timer_start('transport_odd_update')
-        call transport_odd_update( &
-          nx, dx, mat_map, xslib%ngroup, boundary_right, pnorder, sigma_tr, phi)
-        call timer_stop('transport_odd_update')
-        call timer_start('transport_build_transportxs')
-        call transport_build_transportxs(nx, mat_map, xslib, pnorder, phi, sigma_tr)
-        call timer_stop('transport_build_transportxs')
-      endif
-      call timer_start('transport_build_matrix')
-      call transport_build_matrix( &
-        nx, dx, mat_map, xslib, sigma_tr, boundary_right, neven, sub, dia, sup)
-      call timer_stop('transport_build_matrix')
-
-      ! groups are coupled together by fission and upscattering
-      ! fission is just upscattering of the zeroth moment with multiplicity
-      call timer_start('transport_scatter_source')
-      call transport_build_fsource(nx, dx, mat_map, xslib, phi(:,:,1), fsource)
-      call transport_build_upscatter_flip(nx, dx, mat_map, xslib, phi, neven, upsource)
-      call timer_stop('transport_scatter_source')
-
-      ! by solving all moments for one group at-a-time, this is analagous to converging the
-      ! "within group" scattering source in discrete ordinates before proceeding
-      ! to the next group
-
-      ! the PN "next" source does not have group-to-group transfer, only moment-to-moment
-      ! so we may precompute it only once
-      ! NOTE that computing it once per group would save memory
-      ! may be worth considering for 586g ...
-      call timer_start('transport_pn_source')
-      call transport_build_next_source( &
-        nx, dx, xslib%ngroup, boundary_right, neven, sigma_tr, phi, pn_next_source)
-      call timer_stop('transport_pn_source')
-
-      do g = 1,xslib%ngroup
-
-        do n = 1,neven
-
-          idxn = 2*(n-1)
-
-          if (n > 1) then
-            call timer_start('transport_pn_source')
-            call transport_build_prev_source_flip( &
-              nx, dx, boundary_right, sigma_tr, phi, idxn, g, pn_prev_source)
-            call timer_stop('transport_pn_source')
-          endif
-
-          call timer_start('transport_source')
-          call transport_build_downscatter(nx, dx, mat_map, xslib, phi, idxn, g, downsource)
-          call timer_stop('transport_source')
-
-          q = upsource(:,g,n) + downsource
-          if (n == 1) then
-            q = q + fsource(:,g)/keff
-          else ! (n > 1)
-            q = q + pn_prev_source
-          endif
-          if (n < neven) then
-            q = q + pn_next_source(:,g,n)
-          endif
-
-          call timer_start('transport_tridiagonal')
-          ! SOLVE
-          ! need to store copies, trid uses them as scratch space
-          sub_copy = sub(:,g,n)
-          dia_copy = dia(:,g,n)
-          sup_copy = sup(:,g,n)
-          call trid(nx, sub_copy, dia_copy, sup_copy, q, phi(:,g,idxn+1))
-          call timer_stop('transport_tridiagonal')
-
-        enddo ! n = 1,neven
-      enddo ! g = 1,xslib%ngroup
-
-      call timer_start('transport_convergence')
-      ! eigenvalue update
-      fsum = transport_fission_summation(nx, dx, mat_map, xslib, phi(:,:,1))
-      if (iter > 1) keff = keff * fsum / fsum_old
-      delta_k = abs(keff - k_old)
-      ! NOTE: we look at convergence in all space, all groups, all moments!
-      ! This is seriously overkill, but necessary to demonstrate that the odd moments
-      ! are second-order convergent as well.
-      ! Furthermore, we may expect that the higher-order moments are important for
-      ! anisotropic scattering.
-      delta_phi = maxval(abs(phi - phi_old)) / maxval(phi)
-      call timer_stop('transport_convergence')
-
-      ! TODO look at isnan
-      if ((keff < 0.0_rk) .or. (keff > 2.0_rk)) then
-        write(*,*) 'invalid keff', keff
-      endif
-
-      write(line, '(a,i4,a,es8.1,a,es8.1,a,f8.6)') &
-        'it=', iter, ' dk=', delta_k, ' dphi=', delta_phi, ' keff=', keff
-      call output_write(line)
-
-      if ((delta_k < k_tol) .and. (delta_phi < phi_tol)) then
-        call output_write('CONVERGENCE!')
-        call output_write('')
-        exit
-      endif
-
-    enddo ! iter = 1,max_iter
-
-    if (iter > max_iter) then
-      call exception_warning('failed to converge')
-    endif
-
-    deallocate(sub, dia, sup)
-    deallocate(sub_copy, dia_copy, sup_copy)
-    deallocate(fsource, upsource, downsource, q)
-    deallocate(pn_next_source, pn_prev_source)
-    deallocate(phi_old)
-
-  endsubroutine transport_power_iteration_flip
-
   subroutine transport_power_iteration(&
     nx, dx, mat_map, xslib, boundary_right, k_tol, phi_tol, max_iter, pnorder, keff, sigma_tr, phi)
     use xs, only : XSLibrary
@@ -907,8 +617,6 @@ contains
 
     character(1024) :: line
 
-    logical :: isotropic
-
     if (mod(pnorder,2) /= 1) then
       call exception_fatal('pnorder must be odd')
     endif
@@ -936,9 +644,7 @@ contains
     call output_write('=== PN TRANSPORT POWER ITERATION ===')
 
     ! Note that this iterative scheme is the same as that in LUPINE.
-    ! It seems like it may be slightly less stable than that suggested by Gelbard and later Gamino.
 
-    isotropic = .true.
     call timer_start('transport_build_matrix')
     call transport_build_matrix( &
       nx, dx, mat_map, xslib, sigma_tr, boundary_right, neven, sub, dia, sup)
@@ -950,18 +656,19 @@ contains
       phi_old = phi
       fsum_old = fsum
 
-      if (.not. isotropic) then
-        call timer_start('transport_odd_update')
-        call transport_odd_update( &
-          nx, dx, mat_map, xslib%ngroup, boundary_right, pnorder, sigma_tr, phi)
-        call timer_stop('transport_odd_update')
-        call timer_start('transport_build_transportxs')
-        call transport_build_transportxs(nx, mat_map, xslib, pnorder, phi, sigma_tr)
-        call timer_stop('transport_build_transportxs')
-        call timer_start('transport_build_matrix')
-        call transport_build_matrix( &
-          nx, dx, mat_map, xslib, sigma_tr, boundary_right, neven, sub, dia, sup)
-        call timer_stop('transport_build_matrix')
+      if (iter > 1) then
+      ! TODO simplify here
+      call timer_start('transport_odd_update')
+      call transport_odd_update( &
+        nx, dx, mat_map, xslib%ngroup, boundary_right, pnorder, sigma_tr, phi)
+      call timer_stop('transport_odd_update')
+      call timer_start('transport_build_transportxs')
+      call transport_build_transportxs(nx, mat_map, xslib, pnorder, phi, sigma_tr)
+      call timer_stop('transport_build_transportxs')
+      call timer_start('transport_build_matrix')
+      call transport_build_matrix( &
+        nx, dx, mat_map, xslib, sigma_tr, boundary_right, neven, sub, dia, sup)
+      call timer_stop('transport_build_matrix')
       endif
 
       call timer_start('transport_pn_source')
@@ -1038,13 +745,9 @@ contains
       call output_write(line)
 
       if ((delta_k < k_tol) .and. (delta_phi < phi_tol)) then
-        if (.not. isotropic) then
-          call output_write('CONVERGENCE!')
-          call output_write('')
-          exit
-        else
-          isotropic = .false.
-        endif
+        call output_write('CONVERGENCE!')
+        call output_write('')
+        exit
       endif
 
     enddo ! iter = 1,max_iter

--- a/src/transport.f90
+++ b/src/transport.f90
@@ -152,6 +152,11 @@ contains
     integer(ik) :: i, g, n
     integer(ik) :: mthis
 
+    ! NOTE: this can only ever be used.
+    ! It is *not* possible to update the transport xs during the iterative scheme due to non-positive
+    ! values of the flux moments and singularities of the transport xs.
+    ! Effectively, this routine is only useful for the one-group case.
+
     do n = 1,pnorder+1
       if (n <= xslib%nmoment) then
         do g = 1,xslib%ngroup
@@ -171,51 +176,6 @@ contains
     enddo ! n = 1,pnorder+1
 
   endsubroutine transport_init_transportxs
-
-  subroutine transport_build_transportxs(nx, mat_map, xslib, pnorder, phi, sigma_tr)
-    use xs, only : XSLibrary
-    integer(ik), intent(in) :: nx
-    integer(ik), intent(in) :: mat_map(:)
-    type(XSLibrary), intent(in) :: xslib
-    integer(ik), intent(in) :: pnorder
-    real(rk), intent(in) :: phi(:,:,:) ! (nx, ngroup, pnorder)
-    real(rk), intent(out) :: sigma_tr(:,:,:) ! (nx, ngroup, pnorder)
-
-    integer(ik) :: n, g, i
-    integer(ik) :: mthis
-
-    do n = 1,pnorder+1
-      if (n <= xslib%nmoment) then
-        if (mod(n,2) == 0) then
-          ! If n is even, idxn (the actual PN order) is odd... off-by-one
-          do i = 1,nx
-            mthis = mat_map(i)
-            do g = 1,xslib%ngroup
-              sigma_tr(i,g,n) = xslib%mat(mthis)%sigma_t(g) &
-                - sum(xslib%mat(mthis)%scatter(:,g,n)*phi(i,:,n))/phi(i,g,n)
-            enddo ! g = 1,xslib%ngroup
-          enddo ! i = 1,nx
-        else
-          ! I don't really care about the even transport xs.
-          ! They are not used in the calculations anywhere
-          do i = 1,nx
-            mthis = mat_map(i)
-            do g = 1,xslib%ngroup
-              sigma_tr(i,g,n) = xslib%mat(mthis)%sigma_t(g) &
-                - sum(xslib%mat(mthis)%scatter(:,g,n)*phi(i,:,n))/phi(i,g,n)
-            enddo ! xslib%ngroup
-          enddo ! i = 1,nx
-        endif
-      else
-        do i = 1,nx
-          mthis = mat_map(i)
-          do g = 1,xslib%ngroup
-            sigma_tr(i,g,n) = xslib%mat(mthis)%sigma_t(g)
-          enddo ! g = 1,xslib%ngroup
-        enddo ! n = 1,nx
-      endif
-    enddo ! n = 1,pnorder+1
-  endsubroutine transport_build_transportxs
 
   subroutine transport_odd_update(nx, dx, mat_map, ng, boundary_right, pnorder, sigma_tr, phi)
     use numeric, only : deriv
@@ -656,21 +616,6 @@ contains
       phi_old = phi
       fsum_old = fsum
 
-      if (iter > 1) then
-      ! TODO simplify here
-      call timer_start('transport_odd_update')
-      call transport_odd_update( &
-        nx, dx, mat_map, xslib%ngroup, boundary_right, pnorder, sigma_tr, phi)
-      call timer_stop('transport_odd_update')
-      call timer_start('transport_build_transportxs')
-      call transport_build_transportxs(nx, mat_map, xslib, pnorder, phi, sigma_tr)
-      call timer_stop('transport_build_transportxs')
-      call timer_start('transport_build_matrix')
-      call transport_build_matrix( &
-        nx, dx, mat_map, xslib, sigma_tr, boundary_right, neven, sub, dia, sup)
-      call timer_stop('transport_build_matrix')
-      endif
-
       call timer_start('transport_pn_source')
       call transport_build_next_source( &
         nx, dx, xslib%ngroup, boundary_right, neven, sigma_tr, phi, pn_next_source)
@@ -724,6 +669,12 @@ contains
 
         enddo ! g = 1,ngroup
       enddo ! n = 1,neven
+
+      ! always do this update so that we can use it in the convergence criteria
+      call timer_start('transport_odd_update')
+      call transport_odd_update( &
+        nx, dx, mat_map, xslib%ngroup, boundary_right, pnorder, sigma_tr, phi)
+      call timer_stop('transport_odd_update')
 
       call timer_start('transport_convergence')
       ! eigenvalue update


### PR DESCRIPTION
After I've learned about the instabilities of trying to iteratively update the transport xs during convergence, I have opted to remove invalid and dead code. The one-group at-a-time solver with the LUPINE iterative scheme can still be used for PN problems with isotropic scattering, or one-group problems where anisotropic scattering is trivial (in PN form).

Resolves #11 