### PR TITLE
Change pnorder numbering

### DIFF
--- a/cases/URRd-2-0-IN/benchmark2g.xs
+++ b/cases/URRd-2-0-IN/benchmark2g.xs
@@ -1,6 +1,6 @@
 niso 3
 ngroup 2
-nmoment 0
+nmoment 1
 
 name URRd
 

--- a/cases/URRd-H2Ob_1-2-0-ISLC/doit.py
+++ b/cases/URRd-H2Ob_1-2-0-ISLC/doit.py
@@ -49,7 +49,7 @@ def get_nx(lines):
 
 if __name__ == "__main__":
 
-    executable = "/Users/williamdawn/work/siren/src/siren.x"
+    executable = "../..//src/siren.x"
     fname_base = "URRd-H2Ob_1-2-0-ISLC.inp"
     max_pnorder = 21
     max_refine = 12

--- a/cases/analytic_p3/benchmark_new.xs
+++ b/cases/analytic_p3/benchmark_new.xs
@@ -1,6 +1,6 @@
 niso 1
 ngroup 1
-nmoment 0
+nmoment 1
 
 name FUEL
 diffusion

--- a/cases/analytic_p3/doit.py
+++ b/cases/analytic_p3/doit.py
@@ -51,7 +51,7 @@ def get_nx(lines):
 
 if __name__ == "__main__":
 
-    executable = "/Users/wcdawn/work/siren/src/siren.x"
+    executable = "../..//src/siren.x"
     fname_base = "analytic_p3.inp"
     max_refine = 11
 

--- a/cases/benchmark2g.xs
+++ b/cases/benchmark2g.xs
@@ -1,0 +1,1 @@
+./URRd-2-0-IN/benchmark2g.xs

--- a/cases/doit_urrd.py
+++ b/cases/doit_urrd.py
@@ -42,7 +42,7 @@ def get_nx(lines):
 
 if __name__ == "__main__":
 
-    executable = "/Users/williamdawn/work/siren/src/siren.x"
+    executable = "../src/siren.x"
     pnorder = 17
     refine = 12
 

--- a/src/transport.f90
+++ b/src/transport.f90
@@ -186,8 +186,8 @@ contains
     integer(ik), intent(in) :: ng
     character(*), intent(in) :: boundary_right
     integer(ik), intent(in) :: pnorder
-    real(rk), intent(in) :: sigma_tr(:,:,:) ! (nx, ngroup, pnorder)
-    real(rk), intent(inout) :: phi(:,:,:) ! (nx, ngroup, pnorder)
+    real(rk), intent(in) :: sigma_tr(:,:,:) ! (nx, ngroup, pnorder+1)
+    real(rk), intent(inout) :: phi(:,:,:) ! (nx, ngroup, pnorder+1)
 
     integer(ik) :: n, g, i
     integer(ik) :: idxn
@@ -298,7 +298,7 @@ contains
     real(rk), intent(in) :: dx(:) ! (nx)
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     type(XSLibrary), intent(in) :: xslib
-    real(rk), intent(in) :: phi(:,:,:) ! (nx, ngroup, pnorder)
+    real(rk), intent(in) :: phi(:,:,:) ! (nx, ngroup, pnorder+1)
     integer(ik), intent(in) :: idxn
     real(rk), intent(out) :: qup(:,:) ! (nx, ngroup)
 
@@ -325,7 +325,7 @@ contains
     real(rk), intent(in) :: dx(:) ! (nx)
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     type(XSLibrary), intent(in) :: xslib
-    real(rk), intent(in) :: phi(:,:,:) ! (nx, ngroup, pnorder)
+    real(rk), intent(in) :: phi(:,:,:) ! (nx, ngroup, pnorder+1)
     integer(ik), intent(in) :: idxn
     integer(ik), intent(in) :: g
     real(rk), intent(out) :: qdown(:) ! (nx)
@@ -376,8 +376,8 @@ contains
     integer(ik), intent(in) :: ngroup
     character(*), intent(in) :: boundary_right
     integer(ik), intent(in) :: neven
-    real(rk), intent(in) :: sigma_tr(:,:,:) ! (nx, ngroup, pnorder)
-    real(rk), intent(in) :: phi(:,:,:) ! (nx, ngroup, pnorder)
+    real(rk), intent(in) :: sigma_tr(:,:,:) ! (nx, ngroup, pnorder+1)
+    real(rk), intent(in) :: phi(:,:,:) ! (nx, ngroup, pnorder+1)
     real(rk), intent(out) :: qnext(:,:,:) ! (nx, ngroup, neven)
 
     integer(ik) :: i, g, n
@@ -448,8 +448,8 @@ contains
     real(rk), intent(in) :: dx(:) ! (nx)
     integer(ik), intent(in) :: ngroup
     character(*), intent(in) :: boundary_right
-    real(rk), intent(in) :: sigma_tr(:,:,:) ! (nx, ngroup, pnorder)
-    real(rk), intent(in) :: phi(:,:,:) ! (nx, ngroup, pnorder)
+    real(rk), intent(in) :: sigma_tr(:,:,:) ! (nx, ngroup, pnorder+1)
+    real(rk), intent(in) :: phi(:,:,:) ! (nx, ngroup, pnorder+1)
     integer(ik), intent(in) :: idxn
     real(rk), intent(out) :: qprev(:,:) ! (nx, ngroup)
 

--- a/src/xs.f90
+++ b/src/xs.f90
@@ -78,7 +78,6 @@ contains
           read(line, *) card, xslib%niso
         case ('nmoment')
           read(line, *) card, xslib%nmoment
-          xslib%nmoment = xslib%nmoment + 1 ! index begins at 1 in SIREN
         case ('name')
           if (pnt == 0) then
             ! allocate necessary space


### PR DESCRIPTION
This resolves #18 

In reality, `pnorder` was used pretty consistently throughout. This ended up being a change on how `nmoment` was used. Now, `nmoment` is basically used like C-indexing. This makes sense intuitively as that is how the PN orders are numbered (zero-based).

Now, `nmoment` should be the number of scattering matrices provided plus one. For example, isotropic scattering would have `nmoment == 1` and linearly anisotropic scattering would have `nmoment == 2`.

It is the actual number of moments provided, including anisotropic data.