### PR TITLE
Boundary left

### DIFF
--- a/cases/.gitignore
+++ b/cases/.gitignore
@@ -1,3 +1,4 @@
 **.png
 **.csv
 **.out
+**_run.inp

--- a/src/diffusion.f90
+++ b/src/diffusion.f90
@@ -31,45 +31,33 @@ contains
     ! BC at x=0, i=1
     mthis = mat_map(1)
     mnext = mat_map(2)
-    select case (boundary_left)
-      case ('zero')
-        do g = 1,xslib%ngroup
-          if (present(diffusion_coeff)) then
-            dnext = 2 &
-              * (diffusion_coeff(1,g) / dx(1) * diffusion_coeff(2,g) / dx(2)) &
-              / (diffusion_coeff(1,g) / dx(1) + diffusion_coeff(2,g) / dx(2))
-          else
-            dnext = 2 &
-              * (xslib%mat(mthis)%diffusion(g) / dx(1) * xslib%mat(mnext)%diffusion(g) / dx(2)) &
-              / (xslib%mat(mthis)%diffusion(g) / dx(1) + xslib%mat(mnext)%diffusion(g) / dx(2))
-          endif
+    do g = 1,xslib%ngroup
+      if (present(diffusion_coeff)) then
+        dnext = 2 &
+          * (diffusion_coeff(1,g) / dx(1) * diffusion_coeff(2,g) / dx(2)) &
+          / (diffusion_coeff(1,g) / dx(1) + diffusion_coeff(2,g) / dx(2))
+      else
+        dnext = 2 &
+          * (xslib%mat(mthis)%diffusion(g) / dx(1) * xslib%mat(mnext)%diffusion(g) / dx(2)) &
+          / (xslib%mat(mthis)%diffusion(g) / dx(1) + xslib%mat(mnext)%diffusion(g) / dx(2))
+      endif
+      sup(1,g) = -dnext
+      select case (boundary_left)
+        case ('zero')
           dia(1,g) = dnext + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(1)
-          sup(1,g) = -dnext
           if (present(diffusion_coeff)) then
             dia(1,g) = dia(1,g) + 2 * diffusion_coeff(1,g) / dx(1)
           else
             dia(1,g) = dia(1,g) + 2 * xslib%mat(mthis)%diffusion(g) / dx(1)
           endif
-        enddo
-      case ('mirror')
-        do g = 1,xslib%ngroup
-          if (present(diffusion_coeff)) then
-            dnext = 2 &
-              * (diffusion_coeff(1,g) / dx(1) * diffusion_coeff(2,g) / dx(2)) &
-              / (diffusion_coeff(1,g) / dx(1) + diffusion_coeff(2,g) / dx(2))
-          else
-            dnext = 2 &
-              * (xslib%mat(mthis)%diffusion(g) / dx(1) * xslib%mat(mnext)%diffusion(g) / dx(2)) &
-              / (xslib%mat(mthis)%diffusion(g) / dx(1) + xslib%mat(mnext)%diffusion(g) / dx(2))
-          endif
+        case ('mirror')
           dia(1,g) = dnext + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(1)
-          sup(1,g) = -dnext
-        enddo
-      case default
-        call exception_fatal(&
-          'unknown boundary_left in diffusion_build_matrix: '&
-          // trim(adjustl(boundary_left)))
-    endselect
+        case default
+          call exception_fatal(&
+            'unknown boundary_left in diffusion_build_matrix: '&
+            // trim(adjustl(boundary_left)))
+      endselect
+    enddo ! g = 1,xslib%ngroup
 
     do g = 1,xslib%ngroup
       do i = 2,nx-1
@@ -105,19 +93,19 @@ contains
     ! BC at x=L, i=N
     mprev = mat_map(nx-1)
     mthis = mat_map(nx)
-    select case (boundary_right)
-      case ('zero')
-        do g = 1,xslib%ngroup
-          if (present(diffusion_coeff)) then
-            dprev = 2 &
-              * (diffusion_coeff(nx,g) / dx(nx) * diffusion_coeff(nx-1,g) / dx(nx-1)) &
-              / (diffusion_coeff(nx,g) / dx(nx) + diffusion_coeff(nx-1,g) / dx(nx-1))
-          else
-            dprev = 2 &
-              * (xslib%mat(mthis)%diffusion(g) / dx(nx) * xslib%mat(mprev)%diffusion(g) / dx(nx-1)) &
-              / (xslib%mat(mthis)%diffusion(g) / dx(nx) + xslib%mat(mprev)%diffusion(g) / dx(nx-1))
-          endif
-          sub(nx-1,g) = -dprev
+    do g = 1,xslib%ngroup
+      if (present(diffusion_coeff)) then
+        dprev = 2 &
+          * (diffusion_coeff(nx,g) / dx(nx) * diffusion_coeff(nx-1,g) / dx(nx-1)) &
+          / (diffusion_coeff(nx,g) / dx(nx) + diffusion_coeff(nx-1,g) / dx(nx-1))
+      else
+        dprev = 2 &
+          * (xslib%mat(mthis)%diffusion(g) / dx(nx) * xslib%mat(mprev)%diffusion(g) / dx(nx-1)) &
+          / (xslib%mat(mthis)%diffusion(g) / dx(nx) + xslib%mat(mprev)%diffusion(g) / dx(nx-1))
+      endif
+      sub(nx-1,g) = -dprev
+      select case (boundary_right)
+        case ('zero')
           dia(nx,g) = dprev &
             + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(nx)
           if (present(diffusion_coeff)) then
@@ -125,28 +113,15 @@ contains
           else
             dia(nx,g) = dia(nx,g) + 2 * xslib%mat(mthis)%diffusion(g) / dx(nx)
           endif
-        enddo
-      case ('mirror')
-        do g = 1,xslib%ngroup
-          if (present(diffusion_coeff)) then
-            dprev = 2 &
-              * (diffusion_coeff(nx,g) / dx(nx) * diffusion_coeff(nx-1,g) / dx(nx-1)) &
-              / (diffusion_coeff(nx,g) / dx(nx) + diffusion_coeff(nx-1,g) / dx(nx-1))
-          else
-            dprev = 2 &
-              * (xslib%mat(mthis)%diffusion(g) / dx(nx) * xslib%mat(mprev)%diffusion(g) / dx(nx-1)) &
-              / (xslib%mat(mthis)%diffusion(g) / dx(nx) + xslib%mat(mprev)%diffusion(g) / dx(nx-1))
-          endif
-          sub(nx-1,g) = -dprev
+        case ('mirror')
           dia(nx,g) = dprev &
             + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(nx)
-        enddo
-      case default
-        call exception_fatal(&
-          'unknown boundary_right in diffusion_build_matrix: '&
-          // trim(adjustl(boundary_right)))
-    endselect
-
+        case default
+          call exception_fatal(&
+            'unknown boundary_right in diffusion_build_matrix: '&
+            // trim(adjustl(boundary_right)))
+      endselect
+    enddo
   endsubroutine diffusion_build_matrix
 
   subroutine diffusion_build_fsource(nx, dx, mat_map, xslib, flux, fsource)

--- a/src/diffusion_block.f90
+++ b/src/diffusion_block.f90
@@ -7,14 +7,15 @@ public :: diffusion_block_power_iteration
 
 contains
 
-  subroutine diffusion_block_build_matrix(nx, dx, mat_map, xslib, boundary_right, sub, dia, sup)
+  subroutine diffusion_block_build_matrix(nx, dx, mat_map, xslib, &
+      boundary_left, boundary_right, sub, dia, sup)
     use xs, only : XSLibrary
     use exception_handler, only : exception_fatal
     integer(ik), intent(in) :: nx
     real(rk), intent(in) :: dx(:) ! (nx)
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     type(XSLibrary), intent(in) :: xslib
-    character(*), intent(in) :: boundary_right
+    character(*), intent(in) :: boundary_left, boundary_right
     real(rk), intent(out) :: sub(:,:,:) ! (ngroup,ngroup,nx-1)
     real(rk), intent(out) :: dia(:,:,:) ! (ngroup,ngroup,nx)
     real(rk), intent(out) :: sup(:,:,:) ! (ngroup,ngroup,nx-1)
@@ -30,13 +31,28 @@ contains
     ! BC at x=0, i=1 (mirror)
     mthis = mat_map(1)
     mnext = mat_map(2)
-    do g = 1,xslib%ngroup
-      dnext = 2 &
-        * (xslib%mat(mthis)%diffusion(g) / dx(1) * xslib%mat(mnext)%diffusion(g) / dx(2)) &
-        / (xslib%mat(mthis)%diffusion(g) / dx(1) + xslib%mat(mnext)%diffusion(g) / dx(2))
-      dia(g,g,1) = dnext + xslib%mat(mthis)%sigma_t(g) * dx(1)
-      sup(g,g,1) = -dnext
-    enddo ! g = 1,xslib%ngroup
+    select case (boundary_left)
+      case ('zero')
+        do g = 1,xslib%ngroup
+          dnext = 2 &
+            * (xslib%mat(mthis)%diffusion(g) / dx(1) * xslib%mat(mnext)%diffusion(g) / dx(2)) &
+            / (xslib%mat(mthis)%diffusion(g) / dx(1) + xslib%mat(mnext)%diffusion(g) / dx(2))
+          dia(g,g,1) = dnext + xslib%mat(mthis)%sigma_t(g) * dx(1)
+          sup(g,g,1) = -dnext
+          dia(g,g,1) = dia(g,g,1) + 2 * xslib%mat(mthis)%diffusion(g)/dx(nx)
+        enddo ! g = 1,xslib%ngroup
+      case ('mirror')
+        do g = 1,xslib%ngroup
+          dnext = 2 &
+            * (xslib%mat(mthis)%diffusion(g) / dx(1) * xslib%mat(mnext)%diffusion(g) / dx(2)) &
+            / (xslib%mat(mthis)%diffusion(g) / dx(1) + xslib%mat(mnext)%diffusion(g) / dx(2))
+          dia(g,g,1) = dnext + xslib%mat(mthis)%sigma_t(g) * dx(1)
+          sup(g,g,1) = -dnext
+        enddo ! g = 1,xslib%ngroup
+      case default
+        call exception_fatal('unknown boundary_left: ' &
+          // trim(adjustl(boundary_left)))
+    endselect
 
     do i = 2,nx-1
 
@@ -133,7 +149,8 @@ contains
   endfunction diffusion_block_fission_summation
 
   subroutine diffusion_block_power_iteration( &
-    nx, dx, mat_map, xslib, boundary_right, k_tol, phi_tol, max_iter, keff, flux)
+    nx, dx, mat_map, xslib, &
+    boundary_left, boundary_right, k_tol, phi_tol, max_iter, keff, flux)
     use xs, only : XSLibrary
     use linalg, only : trid_block
     use output, only : output_write
@@ -143,7 +160,7 @@ contains
     real(rk), intent(in) :: dx(:) ! (nx)
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     type(XSLibrary), intent(in) :: xslib
-    character(*), intent(in) :: boundary_right
+    character(*), intent(in) :: boundary_left, boundary_right
     real(rk), intent(in) :: k_tol, phi_tol
     integer(ik), intent(in) :: max_iter
     real(rk), intent(out) :: keff
@@ -175,7 +192,8 @@ contains
       sup_copy(xslib%ngroup,xslib%ngroup,nx-1))
 
     call timer_start('diffusion_build_matrix')
-    call diffusion_block_build_matrix(nx, dx, mat_map, xslib, boundary_right, sub, dia, sup)
+    call diffusion_block_build_matrix(nx, dx, mat_map, xslib, &
+      boundary_left, boundary_right, sub, dia, sup)
     call timer_stop('diffusion_build_matrix')
 
     allocate(fsource(xslib%ngroup,nx))

--- a/src/diffusion_block.f90
+++ b/src/diffusion_block.f90
@@ -31,28 +31,25 @@ contains
     ! BC at x=0, i=1 (mirror)
     mthis = mat_map(1)
     mnext = mat_map(2)
-    select case (boundary_left)
-      case ('zero')
-        do g = 1,xslib%ngroup
-          dnext = 2 &
-            * (xslib%mat(mthis)%diffusion(g) / dx(1) * xslib%mat(mnext)%diffusion(g) / dx(2)) &
-            / (xslib%mat(mthis)%diffusion(g) / dx(1) + xslib%mat(mnext)%diffusion(g) / dx(2))
+    do g = 1,xslib%ngroup
+      dnext = 2 &
+        * (xslib%mat(mthis)%diffusion(g) / dx(1) * xslib%mat(mnext)%diffusion(g) / dx(2)) &
+        / (xslib%mat(mthis)%diffusion(g) / dx(1) + xslib%mat(mnext)%diffusion(g) / dx(2))
+      dia(g,g,1) = dnext + xslib%mat(mthis)%sigma_t(g) * dx(1)
+      sup(g,g,1) = -dnext
+      dia(g,g,1) = dia(g,g,1) + 2 * xslib%mat(mthis)%diffusion(g)/dx(1)
+      select case (boundary_left)
+        case ('zero')
+          dia(g,g,1) = dnext + xslib%mat(mthis)%sigma_t(g) * dx(1) &
+            + 2 * xslib%mat(mthis)%diffusion(g)/dx(1)
+        case ('mirror')
           dia(g,g,1) = dnext + xslib%mat(mthis)%sigma_t(g) * dx(1)
-          sup(g,g,1) = -dnext
-          dia(g,g,1) = dia(g,g,1) + 2 * xslib%mat(mthis)%diffusion(g)/dx(1)
-        enddo ! g = 1,xslib%ngroup
-      case ('mirror')
-        do g = 1,xslib%ngroup
-          dnext = 2 &
-            * (xslib%mat(mthis)%diffusion(g) / dx(1) * xslib%mat(mnext)%diffusion(g) / dx(2)) &
-            / (xslib%mat(mthis)%diffusion(g) / dx(1) + xslib%mat(mnext)%diffusion(g) / dx(2))
-          dia(g,g,1) = dnext + xslib%mat(mthis)%sigma_t(g) * dx(1)
-          sup(g,g,1) = -dnext
-        enddo ! g = 1,xslib%ngroup
-      case default
-        call exception_fatal('unknown boundary_left: ' &
-          // trim(adjustl(boundary_left)))
-    endselect
+        case default
+          call exception_fatal(&
+            'unknown boundary_left in diffusion_block_build_matrix: ' &
+            // trim(adjustl(boundary_left)))
+      endselect
+    enddo ! g = 1,xslib%ngroup
 
     do i = 2,nx-1
 
@@ -77,27 +74,23 @@ contains
     ! BC at x=L, i=N
     mprev = mat_map(nx-1)
     mthis = mat_map(nx)
-    select case (boundary_right)
-      case ('zero')
-        do g = 1,xslib%ngroup
-          dprev = 2 &
-            * (xslib%mat(mthis)%diffusion(g) / dx(nx) * xslib%mat(mprev)%diffusion(g) / dx(nx-1)) &
-            / (xslib%mat(mthis)%diffusion(g) / dx(nx) + xslib%mat(mprev)%diffusion(g) / dx(nx-1))
-          sub(g,g,nx-1) = -dprev
+    do g = 1,xslib%ngroup
+      dprev = 2 &
+        * (xslib%mat(mthis)%diffusion(g) / dx(nx) * xslib%mat(mprev)%diffusion(g) / dx(nx-1)) &
+        / (xslib%mat(mthis)%diffusion(g) / dx(nx) + xslib%mat(mprev)%diffusion(g) / dx(nx-1))
+      sub(g,g,nx-1) = -dprev
+      select case (boundary_right)
+        case ('zero')
           dia(g,g,nx) = dprev + xslib%mat(mthis)%sigma_t(g) * dx(nx) &
             + 2 * xslib%mat(mthis)%diffusion(g)/dx(nx)
-        enddo ! g = 1,xslib%ngroup
-      case ('mirror')
-        do g = 1,xslib%ngroup
-          dprev = 2 &
-            * (xslib%mat(mthis)%diffusion(g) / dx(nx) * xslib%mat(mprev)%diffusion(g) / dx(nx-1)) &
-            / (xslib%mat(mthis)%diffusion(g) / dx(nx) + xslib%mat(mprev)%diffusion(g) / dx(nx-1))
-          sub(g,g,nx-1) = -dprev
+        case ('mirror')
           dia(g,g,nx) = dprev + xslib%mat(mthis)%sigma_t(g) * dx(nx)
-        enddo ! g = 1,xslib%ngroup
-      case default
-        call exception_fatal('unknown boundary_right: ' // trim(adjustl(boundary_right)))
-    endselect
+        case default
+          call exception_fatal(&
+            'unknown boundary_right in diffusion_block_build_matrix: ' &
+            // trim(adjustl(boundary_right)))
+      endselect
+    enddo ! g = 1,xslib%ngroup
 
     ! remove scattering
     do i = 1,nx

--- a/src/diffusion_block.f90
+++ b/src/diffusion_block.f90
@@ -35,9 +35,7 @@ contains
       dnext = 2 &
         * (xslib%mat(mthis)%diffusion(g) / dx(1) * xslib%mat(mnext)%diffusion(g) / dx(2)) &
         / (xslib%mat(mthis)%diffusion(g) / dx(1) + xslib%mat(mnext)%diffusion(g) / dx(2))
-      dia(g,g,1) = dnext + xslib%mat(mthis)%sigma_t(g) * dx(1)
       sup(g,g,1) = -dnext
-      dia(g,g,1) = dia(g,g,1) + 2 * xslib%mat(mthis)%diffusion(g)/dx(1)
       select case (boundary_left)
         case ('zero')
           dia(g,g,1) = dnext + xslib%mat(mthis)%sigma_t(g) * dx(1) &

--- a/src/diffusion_block.f90
+++ b/src/diffusion_block.f90
@@ -39,7 +39,7 @@ contains
             / (xslib%mat(mthis)%diffusion(g) / dx(1) + xslib%mat(mnext)%diffusion(g) / dx(2))
           dia(g,g,1) = dnext + xslib%mat(mthis)%sigma_t(g) * dx(1)
           sup(g,g,1) = -dnext
-          dia(g,g,1) = dia(g,g,1) + 2 * xslib%mat(mthis)%diffusion(g)/dx(nx)
+          dia(g,g,1) = dia(g,g,1) + 2 * xslib%mat(mthis)%diffusion(g)/dx(1)
         enddo ! g = 1,xslib%ngroup
       case ('mirror')
         do g = 1,xslib%ngroup

--- a/src/main.f90
+++ b/src/main.f90
@@ -145,7 +145,8 @@ if (pnorder == 0) then
   select case (energy_solver_opt)
     case ('block')
       call diffusion_block_power_iteration( &
-        nx, dx, mat_map, xs, boundary_right, k_tol, phi_tol, max_iter, keff, phi(:,:,1))
+        nx, dx, mat_map, xs, &
+        boundary_left, boundary_right, k_tol, phi_tol, max_iter, keff, phi(:,:,1))
     case ('onegroup')
       call diffusion_power_iteration( &
         nx, dx, mat_map, xs, boundary_left, boundary_right, &

--- a/src/main.f90
+++ b/src/main.f90
@@ -169,8 +169,8 @@ else
       endif
     case ('onegroup')
       call transport_power_iteration(&
-        nx, dx, mat_map, xs, boundary_right, k_tol, phi_tol, max_iter, pnorder, &
-        keff, sigma_tr, phi)
+        nx, dx, mat_map, xs, boundary_left, boundary_right, &
+        k_tol, phi_tol, max_iter, pnorder, keff, sigma_tr, phi)
     case default
       call exception_fatal('unknown energy_solver_opt: ' // trim(adjustl(energy_solver_opt)))
   endselect

--- a/src/main.f90
+++ b/src/main.f90
@@ -159,8 +159,8 @@ else
   select case (energy_solver_opt)
     case ('block')
       call transport_block_power_iteration( &
-        nx, dx, mat_map, xs, boundary_right, calc_type, k_tol, phi_tol, max_iter, pnorder, &
-        keff, sigma_tr, phi)
+        nx, dx, mat_map, xs, boundary_left, boundary_right, calc_type, &
+        k_tol, phi_tol, max_iter, pnorder, keff, sigma_tr, phi)
       if (high_low) then
         call diffusion_power_iteration( &
           nx, dx, mat_map, xs, boundary_left, boundary_right, &

--- a/src/transport.f90
+++ b/src/transport.f90
@@ -225,10 +225,6 @@ contains
     real(rk) :: xn, xmul_prev, xmul_next
     real(rk) :: dphi_prev, dphi_next
 
-    if (boundary_left /= 'mirror') then
-      call exception_fatal('need to implement boundary_left in transport_odd_update')
-    endif
-
     do n = 2,pnorder+1,2
       idxn = n-1
       xn = real(idxn, rk)
@@ -268,7 +264,19 @@ contains
           ! BC at x=0, i=1
           ! use the fact that odd moments must equal zero for mirror bc
           ! this stencil kind of extends to x3 because phi(2) was computed earlier
-          phi(1,g,idxn+1) = phi(2,g,idxn+1) * 0.5_rk * dx(1) / (dx(1) + 0.5_rk*dx(2))
+          select case (boundary_left)
+            case ('mirror')
+              phi(1,g,idxn+1) = phi(2,g,idxn+1) * 0.5_rk * dx(1) / (dx(1) + 0.5_rk*dx(2))
+            case ('zero')
+              dphi_prev = -phi(2,g,idxn+1-1)/(dx(1) + 0.5_rk*dx(2))
+              dphi_next = -phi(2,g,idxn+1+1)/(dx(1) + 0.5_rk*dx(2))
+              phi(1,g,idxn+1) = &
+                - (xmul_prev * dphi_prev + xmul_next * dphi_next) &
+                / sigma_tr(1,g,idxn+1)
+            case default
+              call exception_fatal('unknown boundary_left in odd_update: ' &
+                // trim(adjustl(boundary_left)))
+          endselect
           ! BC at x=L, i=N
           select case (boundary_right)
             case ('mirror')
@@ -277,11 +285,11 @@ contains
               dphi_prev = -phi(nx-1,g,idxn+1-1)/(dx(nx) + 0.5_rk*dx(nx-1))
               dphi_next = -phi(nx-1,g,idxn+1+1)/(dx(nx) + 0.5_rk*dx(nx-1))
               phi(nx,g,idxn+1) = &
-                - (xmul_prev * dphi_prev + xmul_next * dphi_next) &
+                (xmul_prev * dphi_prev + xmul_next * dphi_next) &
                 / sigma_tr(nx,g,idxn+1)
             case default
-              call exception_fatal(&
-                'unknown boundary in odd_update: ' // trim(adjustl(boundary_right)))
+              call exception_fatal('unknown boundary_right in odd_update: ' &
+                // trim(adjustl(boundary_right)))
           endselect
         enddo ! g = 1,ng
       else
@@ -310,7 +318,16 @@ contains
           ! BC at x=0, i=1
           ! use the fact that odd moments must equal zero for mirror bc
           ! this stencil kind of extends to x3 because phi(2) was computed earlier
-          phi(1,g,idxn+1) = phi(2,g,idxn+1) * 0.5_rk * dx(1) / (dx(1) + 0.5_rk*dx(2))
+          select case (boundary_left)
+            case ('mirror')
+              phi(1,g,idxn+1) = phi(2,g,idxn+1) * 0.5_rk * dx(1) / (dx(1) + 0.5_rk*dx(2))
+            case ('zero')
+              dphi_prev = -phi(2,g,idxn+1-1)/(dx(1) + 0.5_rk*dx(2))
+              phi(1,g,idxn+1) = xmul_prev * dphi_prev / sigma_tr(1,g,idxn+1)
+            case default
+              call exception_fatal('unknown boundary_left2 in odd_update: ' &
+                // trim(adjustl(boundary_left)))
+          endselect
           ! BC at x=L, i=N
           select case (boundary_right)
             case ('mirror')
@@ -319,8 +336,8 @@ contains
               dphi_prev = -phi(nx-1,g,idxn+1-1)/(dx(nx) + 0.5_rk*dx(nx-1))
               phi(nx,g,idxn+1) = - xmul_prev * dphi_prev / sigma_tr(nx,g,idxn+1)
             case default
-              call exception_fatal(&
-                'unknown boundary2 in odd_update: ' // trim(adjustl(boundary_right)))
+              call exception_fatal('unknown boundary_right2 in odd_update: ' &
+                // trim(adjustl(boundary_right)))
           endselect
         enddo ! g = 1,ng
       endif
@@ -421,10 +438,6 @@ contains
     real(rk) :: kaprev, kathis, kanext
     real(rk) :: daprev, danext
 
-    if (boundary_left /= 'mirror') then
-      call exception_fatal('need to implement boundary_left in transport_odd_update')
-    endif
-
     qnext(:,:,neven) = 0.0_rk
     do n = 1,neven-1
       idxn = 2*(n-1)
@@ -433,10 +446,24 @@ contains
       do g = 1,ngroup
 
         ! BC at x=0, i=1
-        kathis = xmul/sigma_tr(1,g,idxn+1+1)
-        kanext = xmul/sigma_tr(2,g,idxn+1+1)
-        danext = 2 * kathis / dx(1) * kanext / dx(2) / (kathis / dx(1) + kanext / dx(2))
-        qnext(1,g,n) = -phi(1,g,idxn+1+2)*danext + danext*phi(2,g,idxn+1+2)
+        select case (boundary_left)
+          case ('mirror')
+            kathis = xmul/sigma_tr(1,g,idxn+1+1)
+            kanext = xmul/sigma_tr(2,g,idxn+1+1)
+            danext = 2 * kathis / dx(1) * kanext / dx(2) / (kathis / dx(1) + kanext / dx(2))
+            qnext(1,g,n) = -phi(1,g,idxn+1+2)*danext + danext*phi(2,g,idxn+1+2)
+          case ('zero')
+            kathis = xmul/sigma_tr(1,g,idxn+1+1)
+            kanext = xmul/sigma_tr(2,g,idxn+1+1)
+            danext = 2 * kathis / dx(1) * kanext / dx(2) / (kathis / dx(1) + kanext / dx(2))
+            qnext(1,g,n) = &
+              -phi(1,g,idxn+1+2)*danext &
+              + danext*phi(2,g,idxn+1+2) &
+              - 2 * kathis / dx(1) * phi(1,g,idxn+1+2)
+          case default
+            call exception_fatal('unknown boundary_left in next_source: ' &
+              // trim(adjustl(boundary_left)))
+        endselect
 
         do i = 2,nx-1
 
@@ -499,7 +526,7 @@ contains
     real(rk) :: dbprev, dbnext
 
     if (boundary_left /= 'mirror') then
-      call exception_fatal('need to implement boundary_left in transport_odd_update')
+      call exception_fatal('need to implement boundary_left in transport_build_prev_source')
     endif
 
     xn = real(idxn, rk)

--- a/src/transport.f90
+++ b/src/transport.f90
@@ -9,7 +9,8 @@ public :: transport_power_iteration
 contains
 
   subroutine transport_build_matrix( &
-    nx, dx, mat_map, xslib, sigma_tr, boundary_right, neven, sub, dia, sup)
+    nx, dx, mat_map, xslib, sigma_tr, &
+    boundary_left, boundary_right, neven, sub, dia, sup)
     use xs, only : XSLibrary
     use exception_handler, only : exception_fatal
     integer(ik), intent(in) :: nx
@@ -17,7 +18,7 @@ contains
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     type(XSLibrary), intent(in) :: xslib
     real(rk), intent(in) :: sigma_tr(:,:,:) ! (nx, ngroup, pnorder+1)
-    character(*), intent(in) :: boundary_right
+    character(*), intent(in) :: boundary_left, boundary_right
     integer, intent(in) :: neven
     real(rk), intent(out) :: sub(:,:,:), dia(:,:,:), sup(:,:,:) ! (nx, ngroup, neven)
 
@@ -31,26 +32,55 @@ contains
     ! BC at x=0, i=1
     mthis = mat_map(1)
     mnext = mat_map(2)
-    do n = 1,neven
-      idxn = 2*(n-1)
-      xn = real(idxn, rk)
-      xmul_next = (xn+1.0_rk)**2 / ((2.0_rk*xn+1.0_rk)*(2.0_rk*xn+3.0_rk))
-      xmul_prev = xn**2 / (4.0_rk*xn**2 - 1.0_rk)
-      do g = 1,xslib%ngroup
-        cthis = xmul_next / sigma_tr(1,g,idxn+1+1)
-        cnext = xmul_next / sigma_tr(2,g,idxn+1+1)
-        if (idxn > 1) then
-          cthis = cthis + xmul_prev / sigma_tr(1,g,idxn+1-1)
-          cnext = cnext + xmul_prev / sigma_tr(2,g,idxn+1-1)
-        endif
-        dnext = 2 * cthis / dx(1) * cnext / dx(2) / (cthis / dx(1) + cnext / dx(2))
-        dia(1,g,n) = + dnext + xslib%mat(mthis)%sigma_t(g) * dx(1)
-        if (idxn+1 <= xslib%nmoment) then
-          dia(1,g,n) = dia(1,g,n) - xslib%mat(mthis)%scatter(g,g,idxn+1) * dx(1)
-        endif
-        sup(1,g,n) = -dnext
-      enddo ! = g = 1,xslib%ngroup
-    enddo ! n = 1,neven
+    select case (boundary_left)
+      case ('zero')
+        do n = 1,neven
+          idxn = 2*(n-1)
+          xn = real(idxn, rk)
+          xmul_next = (xn+1.0_rk)**2 / ((2.0_rk*xn+1.0_rk)*(2.0_rk*xn+3.0_rk))
+          xmul_prev = xn**2 / (4.0_rk*xn**2 - 1.0_rk)
+          do g = 1,xslib%ngroup
+            cthis = xmul_next / sigma_tr(1,g,idxn+1+1)
+            cnext = xmul_next / sigma_tr(2,g,idxn+1+1)
+            if (idxn > 1) then
+              cthis = cthis + xmul_prev / sigma_tr(1,g,idxn+1-1)
+              cnext = cnext + xmul_prev / sigma_tr(2,g,idxn+1-1)
+            endif
+            dnext = 2 * cthis / dx(1) * cnext / dx(2) / (cthis / dx(1) + cnext / dx(2))
+            dia(1,g,n) = + dnext + xslib%mat(mthis)%sigma_t(g) * dx(1) &
+              + 2 * cthis / dx(1)
+            if (idxn+1 <= xslib%nmoment) then
+              dia(1,g,n) = dia(1,g,n) - xslib%mat(mthis)%scatter(g,g,idxn+1) * dx(1)
+            endif
+            sup(1,g,n) = -dnext
+          enddo ! = g = 1,xslib%ngroup
+        enddo ! n = 1,neven
+      case ('mirror')
+        do n = 1,neven
+          idxn = 2*(n-1)
+          xn = real(idxn, rk)
+          xmul_next = (xn+1.0_rk)**2 / ((2.0_rk*xn+1.0_rk)*(2.0_rk*xn+3.0_rk))
+          xmul_prev = xn**2 / (4.0_rk*xn**2 - 1.0_rk)
+          do g = 1,xslib%ngroup
+            cthis = xmul_next / sigma_tr(1,g,idxn+1+1)
+            cnext = xmul_next / sigma_tr(2,g,idxn+1+1)
+            if (idxn > 1) then
+              cthis = cthis + xmul_prev / sigma_tr(1,g,idxn+1-1)
+              cnext = cnext + xmul_prev / sigma_tr(2,g,idxn+1-1)
+            endif
+            dnext = 2 * cthis / dx(1) * cnext / dx(2) / (cthis / dx(1) + cnext / dx(2))
+            dia(1,g,n) = + dnext + xslib%mat(mthis)%sigma_t(g) * dx(1)
+            if (idxn+1 <= xslib%nmoment) then
+              dia(1,g,n) = dia(1,g,n) - xslib%mat(mthis)%scatter(g,g,idxn+1) * dx(1)
+            endif
+            sup(1,g,n) = -dnext
+          enddo ! = g = 1,xslib%ngroup
+        enddo ! n = 1,neven
+      case default
+        call exception_fatal( &
+          'unknown boundary_left in transport_build_matrix: ' &
+          // trim(adjustl(boundary_left)))
+    endselect
 
     do n = 1,neven
       idxn = 2*(n-1)
@@ -177,14 +207,15 @@ contains
 
   endsubroutine transport_init_transportxs
 
-  subroutine transport_odd_update(nx, dx, mat_map, ng, boundary_right, pnorder, sigma_tr, phi)
+  subroutine transport_odd_update(nx, dx, mat_map, ng, &
+      boundary_left, boundary_right, pnorder, sigma_tr, phi)
     use numeric, only : deriv
     use exception_handler, only : exception_fatal
     integer(ik), intent(in) :: nx
     real(rk), intent(in) :: dx(:) ! (nx)
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     integer(ik), intent(in) :: ng
-    character(*), intent(in) :: boundary_right
+    character(*), intent(in) :: boundary_left, boundary_right
     integer(ik), intent(in) :: pnorder
     real(rk), intent(in) :: sigma_tr(:,:,:) ! (nx, ngroup, pnorder+1)
     real(rk), intent(inout) :: phi(:,:,:) ! (nx, ngroup, pnorder+1)
@@ -193,6 +224,10 @@ contains
     integer(ik) :: idxn
     real(rk) :: xn, xmul_prev, xmul_next
     real(rk) :: dphi_prev, dphi_next
+
+    if (boundary_left /= 'mirror') then
+      call exception_fatal('need to implement boundary_left in transport_odd_update')
+    endif
 
     do n = 2,pnorder+1,2
       idxn = n-1
@@ -369,12 +404,12 @@ contains
   endsubroutine transport_build_fsource
 
   subroutine transport_build_next_source( &
-    nx, dx, ngroup, boundary_right, neven, sigma_tr, phi, qnext)
+    nx, dx, ngroup, boundary_left, boundary_right, neven, sigma_tr, phi, qnext)
     use exception_handler, only : exception_fatal
     integer(ik), intent(in) :: nx
     real(rk), intent(in) :: dx(:) ! (nx)
     integer(ik), intent(in) :: ngroup
-    character(*), intent(in) :: boundary_right
+    character(*), intent(in) :: boundary_left, boundary_right
     integer(ik), intent(in) :: neven
     real(rk), intent(in) :: sigma_tr(:,:,:) ! (nx, ngroup, pnorder+1)
     real(rk), intent(in) :: phi(:,:,:) ! (nx, ngroup, pnorder+1)
@@ -385,6 +420,10 @@ contains
     real(rk) :: xn, xmul
     real(rk) :: kaprev, kathis, kanext
     real(rk) :: daprev, danext
+
+    if (boundary_left /= 'mirror') then
+      call exception_fatal('need to implement boundary_left in transport_odd_update')
+    endif
 
     qnext(:,:,neven) = 0.0_rk
     do n = 1,neven-1
@@ -442,12 +481,13 @@ contains
 
   endsubroutine transport_build_next_source
 
-  subroutine transport_build_prev_source(nx, dx, ngroup, boundary_right, sigma_tr, phi, idxn, qprev)
+  subroutine transport_build_prev_source(nx, dx, ngroup, &
+      boundary_left, boundary_right, sigma_tr, phi, idxn, qprev)
     use exception_handler, only : exception_fatal
     integer(ik), intent(in) :: nx
     real(rk), intent(in) :: dx(:) ! (nx)
     integer(ik), intent(in) :: ngroup
-    character(*), intent(in) :: boundary_right
+    character(*), intent(in) :: boundary_left, boundary_right
     real(rk), intent(in) :: sigma_tr(:,:,:) ! (nx, ngroup, pnorder+1)
     real(rk), intent(in) :: phi(:,:,:) ! (nx, ngroup, pnorder+1)
     integer(ik), intent(in) :: idxn
@@ -457,6 +497,10 @@ contains
     real(rk) :: xn, xmul
     real(rk) :: kbprev, kbthis, kbnext
     real(rk) :: dbprev, dbnext
+
+    if (boundary_left /= 'mirror') then
+      call exception_fatal('need to implement boundary_left in transport_odd_update')
+    endif
 
     xn = real(idxn, rk)
     xmul = (xn**2-xn)/(4.0_rk*xn**2 - 1.0_rk)
@@ -536,7 +580,8 @@ contains
   endfunction transport_fission_summation
 
   subroutine transport_power_iteration(&
-    nx, dx, mat_map, xslib, boundary_right, k_tol, phi_tol, max_iter, pnorder, keff, sigma_tr, phi)
+    nx, dx, mat_map, xslib, boundary_left, boundary_right, &
+    k_tol, phi_tol, max_iter, pnorder, keff, sigma_tr, phi)
     use xs, only : XSLibrary
     use linalg, only : trid
     use output, only : output_write
@@ -546,7 +591,7 @@ contains
     real(rk), intent(in) :: dx(:) ! (nx)
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     type(XSLibrary), intent(in) :: xslib
-    character(*), intent(in) :: boundary_right
+    character(*), intent(in) :: boundary_left, boundary_right
     real(rk), intent(in) :: k_tol, phi_tol
     integer(ik), intent(in) :: max_iter
     integer(ik), intent(in) :: pnorder
@@ -607,7 +652,8 @@ contains
 
     call timer_start('transport_build_matrix')
     call transport_build_matrix( &
-      nx, dx, mat_map, xslib, sigma_tr, boundary_right, neven, sub, dia, sup)
+      nx, dx, mat_map, xslib, sigma_tr, &
+      boundary_left, boundary_right, neven, sub, dia, sup)
     call timer_stop('transport_build_matrix')
 
     do iter = 1,max_iter
@@ -618,7 +664,8 @@ contains
 
       call timer_start('transport_pn_source')
       call transport_build_next_source( &
-        nx, dx, xslib%ngroup, boundary_right, neven, sigma_tr, phi, pn_next_source)
+        nx, dx, xslib%ngroup, boundary_left, boundary_right, &
+        neven, sigma_tr, phi, pn_next_source)
       call timer_stop('transport_pn_source')
 
       do n = 1,neven
@@ -632,7 +679,8 @@ contains
         else ! (n > 1)
           call timer_start('transport_pn_source')
           call transport_build_prev_source( &
-            nx, dx, xslib%ngroup, boundary_right, sigma_tr, phi, idxn, pn_prev_source)
+            nx, dx, xslib%ngroup, boundary_left, boundary_right, &
+            sigma_tr, phi, idxn, pn_prev_source)
           call timer_stop('transport_pn_source')
         endif
 
@@ -673,7 +721,8 @@ contains
       ! always do this update so that we can use it in the convergence criteria
       call timer_start('transport_odd_update')
       call transport_odd_update( &
-        nx, dx, mat_map, xslib%ngroup, boundary_right, pnorder, sigma_tr, phi)
+        nx, dx, mat_map, xslib%ngroup, boundary_left, boundary_right, &
+        pnorder, sigma_tr, phi)
       call timer_stop('transport_odd_update')
 
       call timer_start('transport_convergence')

--- a/src/transport.f90
+++ b/src/transport.f90
@@ -271,7 +271,7 @@ contains
               dphi_prev = -phi(2,g,idxn+1-1)/(dx(1) + 0.5_rk*dx(2))
               dphi_next = -phi(2,g,idxn+1+1)/(dx(1) + 0.5_rk*dx(2))
               phi(1,g,idxn+1) = &
-                - (xmul_prev * dphi_prev + xmul_next * dphi_next) &
+                (xmul_prev * dphi_prev + xmul_next * dphi_next) &
                 / sigma_tr(1,g,idxn+1)
             case default
               call exception_fatal('unknown boundary_left in odd_update: ' &
@@ -285,7 +285,7 @@ contains
               dphi_prev = -phi(nx-1,g,idxn+1-1)/(dx(nx) + 0.5_rk*dx(nx-1))
               dphi_next = -phi(nx-1,g,idxn+1+1)/(dx(nx) + 0.5_rk*dx(nx-1))
               phi(nx,g,idxn+1) = &
-                (xmul_prev * dphi_prev + xmul_next * dphi_next) &
+                - (xmul_prev * dphi_prev + xmul_next * dphi_next) &
                 / sigma_tr(nx,g,idxn+1)
             case default
               call exception_fatal('unknown boundary_right in odd_update: ' &
@@ -525,20 +525,28 @@ contains
     real(rk) :: kbprev, kbthis, kbnext
     real(rk) :: dbprev, dbnext
 
-    if (boundary_left /= 'mirror') then
-      call exception_fatal('need to implement boundary_left in transport_build_prev_source')
-    endif
-
     xn = real(idxn, rk)
     xmul = (xn**2-xn)/(4.0_rk*xn**2 - 1.0_rk)
 
     do g = 1,ngroup
 
       ! BC at x=0, i=1
-      kbthis = xmul/sigma_tr(1,g,idxn+1-1)
-      kbnext = xmul/sigma_tr(2,g,idxn+1-1)
-      dbnext = 2 * kbthis / dx(1) * kbnext / dx(2) / (kbthis / dx(1) + kbnext / dx(2))
-      qprev(1,g) = -phi(1,g,idxn+1-2)*dbnext + dbnext*phi(2,g,idxn+1-2)
+      select case (boundary_left)
+        case ('zero')
+          kbthis = xmul/sigma_tr(1,g,idxn+1-1)
+          kbnext = xmul/sigma_tr(2,g,idxn+1-1)
+          dbnext = 2 * kbthis / dx(1) * kbnext / dx(2) / (kbthis / dx(1) + kbnext / dx(2))
+          qprev(1,g) = -phi(1,g,idxn+1-2)*dbnext + dbnext*phi(2,g,idxn+1-2) &
+            - 2 * kbthis / dx(1) * phi(1,g,idxn+1-2)
+        case ('mirror')
+          kbthis = xmul/sigma_tr(1,g,idxn+1-1)
+          kbnext = xmul/sigma_tr(2,g,idxn+1-1)
+          dbnext = 2 * kbthis / dx(1) * kbnext / dx(2) / (kbthis / dx(1) + kbnext / dx(2))
+          qprev(1,g) = -phi(1,g,idxn+1-2)*dbnext + dbnext*phi(2,g,idxn+1-2)
+        case default
+          call exception_fatal('unknown boundary_left in prev_source: ' &
+            // trim(adjustl(boundary_left)))
+      endselect
 
       do i = 2,nx-1
 
@@ -574,8 +582,8 @@ contains
             - phi(nx,g,idxn+1-2)*dbprev &
             - 2 * kbthis / dx(nx) * phi(nx,g,idxn+1-2)
         case default
-          call exception_fatal( &
-            'unknown boundary in prev_source: ' // trim(adjustl(boundary_right)))
+          call exception_fatal('unknown boundary_right in prev_source: ' &
+            // trim(adjustl(boundary_right)))
       endselect
 
     enddo ! g = 1,ngroup

--- a/src/transport.f90
+++ b/src/transport.f90
@@ -32,55 +32,36 @@ contains
     ! BC at x=0, i=1
     mthis = mat_map(1)
     mnext = mat_map(2)
-    select case (boundary_left)
-      case ('zero')
-        do n = 1,neven
-          idxn = 2*(n-1)
-          xn = real(idxn, rk)
-          xmul_next = (xn+1.0_rk)**2 / ((2.0_rk*xn+1.0_rk)*(2.0_rk*xn+3.0_rk))
-          xmul_prev = xn**2 / (4.0_rk*xn**2 - 1.0_rk)
-          do g = 1,xslib%ngroup
-            cthis = xmul_next / sigma_tr(1,g,idxn+1+1)
-            cnext = xmul_next / sigma_tr(2,g,idxn+1+1)
-            if (idxn > 1) then
-              cthis = cthis + xmul_prev / sigma_tr(1,g,idxn+1-1)
-              cnext = cnext + xmul_prev / sigma_tr(2,g,idxn+1-1)
-            endif
-            dnext = 2 * cthis / dx(1) * cnext / dx(2) / (cthis / dx(1) + cnext / dx(2))
+    do n = 1,neven
+      idxn = 2*(n-1)
+      xn = real(idxn, rk)
+      xmul_next = (xn+1.0_rk)**2 / ((2.0_rk*xn+1.0_rk)*(2.0_rk*xn+3.0_rk))
+      xmul_prev = xn**2 / (4.0_rk*xn**2 - 1.0_rk)
+      do g = 1,xslib%ngroup
+        cthis = xmul_next / sigma_tr(1,g,idxn+1+1)
+        cnext = xmul_next / sigma_tr(2,g,idxn+1+1)
+        if (idxn > 1) then
+          cthis = cthis + xmul_prev / sigma_tr(1,g,idxn+1-1)
+          cnext = cnext + xmul_prev / sigma_tr(2,g,idxn+1-1)
+        endif
+        dnext = 2 * cthis / dx(1) * cnext / dx(2) / (cthis / dx(1) + cnext / dx(2))
+        select case (boundary_left)
+          case ('zero')
             dia(1,g,n) = + dnext + xslib%mat(mthis)%sigma_t(g) * dx(1) &
               + 2 * cthis / dx(1)
-            if (idxn+1 <= xslib%nmoment) then
-              dia(1,g,n) = dia(1,g,n) - xslib%mat(mthis)%scatter(g,g,idxn+1) * dx(1)
-            endif
-            sup(1,g,n) = -dnext
-          enddo ! = g = 1,xslib%ngroup
-        enddo ! n = 1,neven
-      case ('mirror')
-        do n = 1,neven
-          idxn = 2*(n-1)
-          xn = real(idxn, rk)
-          xmul_next = (xn+1.0_rk)**2 / ((2.0_rk*xn+1.0_rk)*(2.0_rk*xn+3.0_rk))
-          xmul_prev = xn**2 / (4.0_rk*xn**2 - 1.0_rk)
-          do g = 1,xslib%ngroup
-            cthis = xmul_next / sigma_tr(1,g,idxn+1+1)
-            cnext = xmul_next / sigma_tr(2,g,idxn+1+1)
-            if (idxn > 1) then
-              cthis = cthis + xmul_prev / sigma_tr(1,g,idxn+1-1)
-              cnext = cnext + xmul_prev / sigma_tr(2,g,idxn+1-1)
-            endif
-            dnext = 2 * cthis / dx(1) * cnext / dx(2) / (cthis / dx(1) + cnext / dx(2))
+          case ('mirror')
             dia(1,g,n) = + dnext + xslib%mat(mthis)%sigma_t(g) * dx(1)
-            if (idxn+1 <= xslib%nmoment) then
-              dia(1,g,n) = dia(1,g,n) - xslib%mat(mthis)%scatter(g,g,idxn+1) * dx(1)
-            endif
-            sup(1,g,n) = -dnext
-          enddo ! = g = 1,xslib%ngroup
-        enddo ! n = 1,neven
-      case default
-        call exception_fatal( &
-          'unknown boundary_left in transport_build_matrix: ' &
-          // trim(adjustl(boundary_left)))
-    endselect
+          case default
+            call exception_fatal( &
+              'unknown boundary_left in transport_build_matrix: ' &
+              // trim(adjustl(boundary_left)))
+        endselect
+        if (idxn+1 <= xslib%nmoment) then
+          dia(1,g,n) = dia(1,g,n) - xslib%mat(mthis)%scatter(g,g,idxn+1) * dx(1)
+        endif
+        sup(1,g,n) = -dnext
+      enddo ! = g = 1,xslib%ngroup
+    enddo ! n = 1,neven
 
     do n = 1,neven
       idxn = 2*(n-1)
@@ -120,55 +101,36 @@ contains
     ! BC at x=L, i=N
     mprev = mat_map(nx-1)
     mthis = mat_map(nx)
-    select case (boundary_right)
-      case ('mirror')
-        do n = 1,neven
-          idxn = 2*(n-1)
-          xn = real(idxn, rk)
-          xmul_next = (xn+1.0_rk)**2 / ((2.0_rk*xn+1.0_rk)*(2.0_rk*xn+3.0_rk))
-          xmul_prev = xn**2 / (4.0_rk*xn**2 - 1.0_rk)
-          do g = 1,xslib%ngroup
-            cprev = xmul_next / sigma_tr(nx-1,g,idxn+1+1)
-            cthis = xmul_next / sigma_tr(nx  ,g,idxn+1+1)
-            if (idxn > 0) then
-              cprev = cprev + xmul_prev / sigma_tr(nx-1,g,idxn+1-1)
-              cthis = cthis + xmul_prev / sigma_tr(nx  ,g,idxn+1-1)
-            endif
-            dprev = 2 * cthis / dx(nx) * cprev / dx(nx-1) / (cthis / dx(nx) + cprev / dx(nx-1))
-            sub(nx-1,g,n) = -dprev
+    do n = 1,neven
+      idxn = 2*(n-1)
+      xn = real(idxn, rk)
+      xmul_next = (xn+1.0_rk)**2 / ((2.0_rk*xn+1.0_rk)*(2.0_rk*xn+3.0_rk))
+      xmul_prev = xn**2 / (4.0_rk*xn**2 - 1.0_rk)
+      do g = 1,xslib%ngroup
+        cprev = xmul_next / sigma_tr(nx-1,g,idxn+1+1)
+        cthis = xmul_next / sigma_tr(nx  ,g,idxn+1+1)
+        if (idxn > 0) then
+          cprev = cprev + xmul_prev / sigma_tr(nx-1,g,idxn+1-1)
+          cthis = cthis + xmul_prev / sigma_tr(nx  ,g,idxn+1-1)
+        endif
+        dprev = 2 * cthis / dx(nx) * cprev / dx(nx-1) / (cthis / dx(nx) + cprev / dx(nx-1))
+        sub(nx-1,g,n) = -dprev
+        select case (boundary_right)
+          case ('mirror')
             dia(nx,g,n) = dprev + xslib%mat(mthis)%sigma_t(g) * dx(nx)
-            if (idxn+1 <= xslib%nmoment) then
-              dia(nx,g,n) = dia(nx,g,n) - xslib%mat(mthis)%scatter(g,g,idxn+1) * dx(nx)
-            endif
-          enddo ! g = 1,xslib%ngroup
-        enddo ! n = 1,neven
-      case ('zero')
-        do n = 1,neven
-          idxn = 2*(n-1)
-          xn = real(idxn, rk)
-          xmul_next = (xn+1.0_rk)**2 / ((2.0_rk*xn+1.0_rk)*(2.0_rk*xn+3.0_rk))
-          xmul_prev = xn**2 / (4.0_rk*xn**2 - 1.0_rk)
-          do g = 1,xslib%ngroup
-            cprev = xmul_next / sigma_tr(nx-1,g,idxn+1+1)
-            cthis = xmul_next / sigma_tr(nx  ,g,idxn+1+1)
-            if (idxn > 0) then
-              cprev = cprev + xmul_prev / sigma_tr(nx-1,g,idxn+1-1)
-              cthis = cthis + xmul_prev / sigma_tr(nx  ,g,idxn+1-1)
-            endif
-            dprev = 2 * cthis / dx(nx) * cprev / dx(nx-1) / (cthis / dx(nx) + cprev / dx(nx-1))
-            sub(nx-1,g,n) = -dprev
+          case ('zero')
             dia(nx,g,n) = dprev + xslib%mat(mthis)%sigma_t(g) * dx(nx) &
               + 2 * cthis / dx(nx)
-            if (idxn+1 <= xslib%nmoment) then
-              dia(nx,g,n) = dia(nx,g,n) - xslib%mat(mthis)%scatter(g,g,idxn+1) * dx(nx)
-            endif
-          enddo ! g = 1,xslib%ngroup
-        enddo ! n = 1,neven
-      case default
-        call exception_fatal( &
-          'unknown boundary_right in transport_build_matrix: ' // &
-          trim(adjustl(boundary_right)))
-    endselect
+          case default
+            call exception_fatal( &
+              'unknown boundary_right in transport_build_matrix: ' // &
+              trim(adjustl(boundary_right)))
+        endselect
+        if (idxn+1 <= xslib%nmoment) then
+          dia(nx,g,n) = dia(nx,g,n) - xslib%mat(mthis)%scatter(g,g,idxn+1) * dx(nx)
+        endif
+      enddo ! g = 1,xslib%ngroup
+    enddo ! n = 1,neven
   endsubroutine transport_build_matrix
 
   subroutine transport_init_transportxs(nx, mat_map, xslib, pnorder, sigma_tr)
@@ -446,16 +408,13 @@ contains
       do g = 1,ngroup
 
         ! BC at x=0, i=1
+        kathis = xmul/sigma_tr(1,g,idxn+1+1)
+        kanext = xmul/sigma_tr(2,g,idxn+1+1)
+        danext = 2 * kathis / dx(1) * kanext / dx(2) / (kathis / dx(1) + kanext / dx(2))
         select case (boundary_left)
           case ('mirror')
-            kathis = xmul/sigma_tr(1,g,idxn+1+1)
-            kanext = xmul/sigma_tr(2,g,idxn+1+1)
-            danext = 2 * kathis / dx(1) * kanext / dx(2) / (kathis / dx(1) + kanext / dx(2))
             qnext(1,g,n) = -phi(1,g,idxn+1+2)*danext + danext*phi(2,g,idxn+1+2)
           case ('zero')
-            kathis = xmul/sigma_tr(1,g,idxn+1+1)
-            kanext = xmul/sigma_tr(2,g,idxn+1+1)
-            danext = 2 * kathis / dx(1) * kanext / dx(2) / (kathis / dx(1) + kanext / dx(2))
             qnext(1,g,n) = &
               -phi(1,g,idxn+1+2)*danext &
               + danext*phi(2,g,idxn+1+2) &
@@ -482,18 +441,15 @@ contains
         enddo
 
         ! BC at x=L, i=N
+        kaprev = xmul/sigma_tr(nx-1,g,idxn+1+1)
+        kathis = xmul/sigma_tr(nx  ,g,idxn+1+1)
+        daprev = 2 * kathis / dx(nx) * kaprev / dx(nx-1) / (kathis / dx(nx) + kaprev / dx(nx-1))
         select case (boundary_right)
           case ('mirror')
-            kaprev = xmul/sigma_tr(nx-1,g,idxn+1+1)
-            kathis = xmul/sigma_tr(nx  ,g,idxn+1+1)
-            daprev = 2 * kathis / dx(nx) * kaprev / dx(nx-1) / (kathis / dx(nx) + kaprev / dx(nx-1))
             qnext(nx,g,n) = &
               phi(nx-1,g,idxn+1+2)*daprev &
               - phi(nx,g,idxn+1+2)*daprev
           case ('zero')
-            kaprev = xmul/sigma_tr(nx-1,g,idxn+1+1)
-            kathis = xmul/sigma_tr(nx  ,g,idxn+1+1)
-            daprev = 2 * kathis / dx(nx) * kaprev / dx(nx-1) / (kathis / dx(nx) + kaprev / dx(nx-1))
             qnext(nx,g,n) = &
               phi(nx-1,g,idxn+1+2)*daprev &
               - phi(nx,g,idxn+1+2)*daprev &
@@ -531,17 +487,14 @@ contains
     do g = 1,ngroup
 
       ! BC at x=0, i=1
+      kbthis = xmul/sigma_tr(1,g,idxn+1-1)
+      kbnext = xmul/sigma_tr(2,g,idxn+1-1)
+      dbnext = 2 * kbthis / dx(1) * kbnext / dx(2) / (kbthis / dx(1) + kbnext / dx(2))
       select case (boundary_left)
         case ('zero')
-          kbthis = xmul/sigma_tr(1,g,idxn+1-1)
-          kbnext = xmul/sigma_tr(2,g,idxn+1-1)
-          dbnext = 2 * kbthis / dx(1) * kbnext / dx(2) / (kbthis / dx(1) + kbnext / dx(2))
           qprev(1,g) = -phi(1,g,idxn+1-2)*dbnext + dbnext*phi(2,g,idxn+1-2) &
             - 2 * kbthis / dx(1) * phi(1,g,idxn+1-2)
         case ('mirror')
-          kbthis = xmul/sigma_tr(1,g,idxn+1-1)
-          kbnext = xmul/sigma_tr(2,g,idxn+1-1)
-          dbnext = 2 * kbthis / dx(1) * kbnext / dx(2) / (kbthis / dx(1) + kbnext / dx(2))
           qprev(1,g) = -phi(1,g,idxn+1-2)*dbnext + dbnext*phi(2,g,idxn+1-2)
         case default
           call exception_fatal('unknown boundary_left in prev_source: ' &
@@ -565,18 +518,15 @@ contains
       enddo ! i = 2,nx-1
 
       ! BC at x=L, i=N
+      kbprev = xmul/sigma_tr(nx-1,g,idxn+1-1)
+      kbthis = xmul/sigma_tr(nx  ,g,idxn+1-1)
+      dbprev = 2 * kbthis / dx(nx) * kbprev / dx(nx-1) / (kbthis / dx(nx) + kbprev / dx(nx-1))
       select case (boundary_right)
         case ('mirror')
-          kbprev = xmul/sigma_tr(nx-1,g,idxn+1-1)
-          kbthis = xmul/sigma_tr(nx  ,g,idxn+1-1)
-          dbprev = 2 * kbthis / dx(nx) * kbprev / dx(nx-1) / (kbthis / dx(nx) + kbprev / dx(nx-1))
           qprev(nx,g) = &
             phi(nx-1,g,idxn+1-2)*dbprev &
             - phi(nx,g,idxn+1-2)*dbprev
         case ('zero')
-          kbprev = xmul/sigma_tr(nx-1,g,idxn+1-1)
-          kbthis = xmul/sigma_tr(nx  ,g,idxn+1-1)
-          dbprev = 2 * kbthis / dx(nx) * kbprev / dx(nx-1) / (kbthis / dx(nx) + kbprev / dx(nx-1))
           qprev(nx,g) = &
             phi(nx-1,g,idxn+1-2)*dbprev &
             - phi(nx,g,idxn+1-2)*dbprev &

--- a/src/transport.f90
+++ b/src/transport.f90
@@ -192,117 +192,80 @@ contains
       xn = real(idxn, rk)
       xmul_prev = xn/(2.0_rk*xn+1.0_rk)
       xmul_next = (xn+1.0_rk)/(2.0_rk*xn+1.0_rk)
-      if (n < pnorder+1) then
-        do g = 1,ng
-          do i = 2,nx-1
-            if ((mat_map(i) == mat_map(i+1)) .and. (mat_map(i) == mat_map(i-1))) then
-              ! central difference for interior (second order)
-              dphi_prev = deriv(-0.5_rk*(dx(i-1)+dx(i)), 0.0_rk, +0.5_rk*(dx(i)+dx(i+1)), &
-                phi(i-1,g,idxn+1-1), phi(i,g,idxn+1-1), phi(i+1,g,idxn+1-1))
+      dphi_next = 0.0_rk
+      do g = 1,ng
+        do i = 2,nx-1
+          if ((mat_map(i) == mat_map(i+1)) .and. (mat_map(i) == mat_map(i-1))) then
+            ! central difference for interior (second order)
+            dphi_prev = deriv(-0.5_rk*(dx(i-1)+dx(i)), 0.0_rk, +0.5_rk*(dx(i)+dx(i+1)), &
+              phi(i-1,g,idxn+1-1), phi(i,g,idxn+1-1), phi(i+1,g,idxn+1-1))
+            if (n < pnorder + 1) then
               dphi_next = deriv(-0.5_rk*(dx(i-1)+dx(i)), 0.0_rk, +0.5_rk*(dx(i)+dx(i+1)), &
                 phi(i-1,g,idxn+1+1), phi(i,g,idxn+1+1), phi(i+1,g,idxn+1+1))
-            elseif (mat_map(i) == mat_map(i+1)) then
-              ! forward difference (first order)
-              dphi_prev = (phi(i+1,g,idxn+1-1) - phi(i,g,idxn+1-1))/(0.5d0*(dx(i)+dx(i+1)))
+            endif
+          elseif (mat_map(i) == mat_map(i+1)) then
+            ! forward difference (first order)
+            dphi_prev = (phi(i+1,g,idxn+1-1) - phi(i,g,idxn+1-1))/(0.5d0*(dx(i)+dx(i+1)))
+            if (n < pnorder + 1) then
               dphi_next = (phi(i+1,g,idxn+1+1) - phi(i,g,idxn+1+1))/(0.5d0*(dx(i)+dx(i+1)))
-            elseif (mat_map(i) == mat_map(i-1)) then
-              ! backward difference (first order)
-              dphi_prev = (phi(i,g,idxn+1-1) - phi(i-1,g,idxn+1-1))/(0.5d0*(dx(i)+dx(i-1)))
+            endif
+          elseif (mat_map(i) == mat_map(i-1)) then
+            ! backward difference (first order)
+            dphi_prev = (phi(i,g,idxn+1-1) - phi(i-1,g,idxn+1-1))/(0.5d0*(dx(i)+dx(i-1)))
+            if (n < pnorder + 1) then
               dphi_next = (phi(i,g,idxn+1+1) - phi(i-1,g,idxn+1+1))/(0.5d0*(dx(i)+dx(i-1)))
-            else
-              ! this means that there is a material region with width of a single cell
-              ! what a terrible idea...
-              ! try central difference because why not
-              ! TODO raise warning probably in the input processing
-              dphi_prev = deriv(-0.5_rk*(dx(i-1)+dx(i)), 0.0_rk, +0.5_rk*(dx(i)+dx(i+1)), &
-                phi(i-1,g,idxn+1-1), phi(i,g,idxn+1-1), phi(i+1,g,idxn+1-1))
+            endif
+          else
+            ! this means that there is a material region with width of a single cell
+            ! what a terrible idea...
+            ! try central difference because why not
+            ! TODO raise warning probably in the input processing
+            dphi_prev = deriv(-0.5_rk*(dx(i-1)+dx(i)), 0.0_rk, +0.5_rk*(dx(i)+dx(i+1)), &
+              phi(i-1,g,idxn+1-1), phi(i,g,idxn+1-1), phi(i+1,g,idxn+1-1))
+            if (n  < pnorder + 1) then
               dphi_next = deriv(-0.5_rk*(dx(i-1)+dx(i)), 0.0_rk, +0.5_rk*(dx(i)+dx(i+1)), &
                 phi(i-1,g,idxn+1+1), phi(i,g,idxn+1+1), phi(i+1,g,idxn+1+1))
             endif
-            phi(i,g,idxn+1) = &
-              - (xmul_prev * dphi_prev + xmul_next * dphi_next) &
-              / sigma_tr(i,g,idxn+1)
-          enddo ! i = 2,nx-1
-          ! BC at x=0, i=1
-          ! use the fact that odd moments must equal zero for mirror bc
-          ! this stencil kind of extends to x3 because phi(2) was computed earlier
-          select case (boundary_left)
-            case ('mirror')
-              phi(1,g,idxn+1) = phi(2,g,idxn+1) * 0.5_rk * dx(1) / (dx(1) + 0.5_rk*dx(2))
-            case ('zero')
-              dphi_prev = -phi(2,g,idxn+1-1)/(dx(1) + 0.5_rk*dx(2))
+          endif
+          phi(i,g,idxn+1) = &
+            - (xmul_prev * dphi_prev + xmul_next * dphi_next) &
+            / sigma_tr(i,g,idxn+1)
+        enddo ! i = 2,nx-1
+        ! BC at x=0, i=1
+        ! use the fact that odd moments must equal zero for mirror bc
+        ! this stencil kind of extends to x3 because phi(2) was computed earlier
+        select case (boundary_left)
+          case ('mirror')
+            phi(1,g,idxn+1) = phi(2,g,idxn+1) * 0.5_rk * dx(1) / (dx(1) + 0.5_rk*dx(2))
+          case ('zero')
+            dphi_prev = -phi(2,g,idxn+1-1)/(dx(1) + 0.5_rk*dx(2))
+            if (n < pnorder + 1) then
               dphi_next = -phi(2,g,idxn+1+1)/(dx(1) + 0.5_rk*dx(2))
-              phi(1,g,idxn+1) = &
-                (xmul_prev * dphi_prev + xmul_next * dphi_next) &
-                / sigma_tr(1,g,idxn+1)
-            case default
-              call exception_fatal('unknown boundary_left in odd_update: ' &
-                // trim(adjustl(boundary_left)))
-          endselect
-          ! BC at x=L, i=N
-          select case (boundary_right)
-            case ('mirror')
-              phi(nx,g,idxn+1) = phi(nx-1,g,idxn+1) * 0.5_rk*dx(nx) / (dx(nx)+0.5_rk*dx(nx-1))
-            case ('zero')
-              dphi_prev = -phi(nx-1,g,idxn+1-1)/(dx(nx) + 0.5_rk*dx(nx-1))
-              dphi_next = -phi(nx-1,g,idxn+1+1)/(dx(nx) + 0.5_rk*dx(nx-1))
-              phi(nx,g,idxn+1) = &
-                - (xmul_prev * dphi_prev + xmul_next * dphi_next) &
-                / sigma_tr(nx,g,idxn+1)
-            case default
-              call exception_fatal('unknown boundary_right in odd_update: ' &
-                // trim(adjustl(boundary_right)))
-          endselect
-        enddo ! g = 1,ng
-      else
-        do g = 1,ng
-          do i = 2,nx-1
-            if ((mat_map(i) == mat_map(i+1)) .and. (mat_map(i) == mat_map(i-1))) then
-              ! central difference for interior (second order)
-              dphi_prev = deriv(-0.5_rk*(dx(i-1)+dx(i)), 0.0_rk, +0.5_rk*(dx(i)+dx(i+1)), &
-                phi(i-1,g,idxn+1-1), phi(i,g,idxn+1-1), phi(i+1,g,idxn+1-1))
-            elseif (mat_map(i) == mat_map(i+1)) then
-              ! forward difference (first order)
-              dphi_prev = (phi(i+1,g,idxn+1-1) - phi(i,g,idxn+1-1))/(0.5d0*(dx(i)+dx(i+1)))
-            elseif (mat_map(i) == mat_map(i-1)) then
-              ! backward difference (first order)
-              dphi_prev = (phi(i,g,idxn+1-1) - phi(i-1,g,idxn+1-1))/(0.5d0*(dx(i)+dx(i-1)))
-            else
-              ! this means that there is a material region with width of a single cell
-              ! what a terrible idea...
-              ! try central difference because why not
-              ! TODO raise warning probably in the input processing
-              dphi_prev = deriv(-0.5_rk*(dx(i-1)+dx(i)), 0.0_rk, +0.5_rk*(dx(i)+dx(i+1)), &
-                phi(i-1,g,idxn+1-1), phi(i,g,idxn+1-1), phi(i+1,g,idxn+1-1))
             endif
-            phi(i,g,idxn+1) = - xmul_prev * dphi_prev / sigma_tr(i,g,idxn+1)
-          enddo ! i = 2,nx-1
-          ! BC at x=0, i=1
-          ! use the fact that odd moments must equal zero for mirror bc
-          ! this stencil kind of extends to x3 because phi(2) was computed earlier
-          select case (boundary_left)
-            case ('mirror')
-              phi(1,g,idxn+1) = phi(2,g,idxn+1) * 0.5_rk * dx(1) / (dx(1) + 0.5_rk*dx(2))
-            case ('zero')
-              dphi_prev = -phi(2,g,idxn+1-1)/(dx(1) + 0.5_rk*dx(2))
-              phi(1,g,idxn+1) = xmul_prev * dphi_prev / sigma_tr(1,g,idxn+1)
-            case default
-              call exception_fatal('unknown boundary_left2 in odd_update: ' &
-                // trim(adjustl(boundary_left)))
-          endselect
-          ! BC at x=L, i=N
-          select case (boundary_right)
-            case ('mirror')
-              phi(nx,g,idxn+1) = phi(nx-1,g,idxn+1) * 0.5_rk*dx(nx) / (dx(nx)+0.5_rk*dx(nx-1))
-            case ('zero')
-              dphi_prev = -phi(nx-1,g,idxn+1-1)/(dx(nx) + 0.5_rk*dx(nx-1))
-              phi(nx,g,idxn+1) = - xmul_prev * dphi_prev / sigma_tr(nx,g,idxn+1)
-            case default
-              call exception_fatal('unknown boundary_right2 in odd_update: ' &
-                // trim(adjustl(boundary_right)))
-          endselect
-        enddo ! g = 1,ng
-      endif
+            phi(1,g,idxn+1) = &
+              (xmul_prev * dphi_prev + xmul_next * dphi_next) &
+              / sigma_tr(1,g,idxn+1)
+          case default
+            call exception_fatal('unknown boundary_left in odd_update: ' &
+              // trim(adjustl(boundary_left)))
+        endselect
+        ! BC at x=L, i=N
+        select case (boundary_right)
+          case ('mirror')
+            phi(nx,g,idxn+1) = phi(nx-1,g,idxn+1) * 0.5_rk*dx(nx) / (dx(nx)+0.5_rk*dx(nx-1))
+          case ('zero')
+            dphi_prev = -phi(nx-1,g,idxn+1-1)/(dx(nx) + 0.5_rk*dx(nx-1))
+            if (n < pnorder + 1) then
+              dphi_next = -phi(nx-1,g,idxn+1+1)/(dx(nx) + 0.5_rk*dx(nx-1))
+            endif
+            phi(nx,g,idxn+1) = &
+              - (xmul_prev * dphi_prev + xmul_next * dphi_next) &
+              / sigma_tr(nx,g,idxn+1)
+          case default
+            call exception_fatal('unknown boundary_right in odd_update: ' &
+              // trim(adjustl(boundary_right)))
+        endselect
+      enddo ! g = 1,ng
     enddo ! n = 2,pnorder+1,2
   endsubroutine transport_odd_update
 

--- a/src/transport_block.f90
+++ b/src/transport_block.f90
@@ -40,7 +40,7 @@ contains
   endsubroutine transport_invtransmat
 
   subroutine transport_block_build_matrix( &
-    nx, dx, mat_map, xslib, boundary_right, neven, sub, dia, sup)
+    nx, dx, mat_map, xslib, boundary_left, boundary_right, neven, sub, dia, sup)
     use xs, only : XSLibrary
     use linalg, only : inv
     use omp_lib, only : omp_get_num_threads, omp_get_thread_num
@@ -49,7 +49,7 @@ contains
     real(rk), intent(in) :: dx(:) ! (nx)
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     type(XSLibrary), intent(in) :: xslib
-    character(*), intent(in) :: boundary_right
+    character(*), intent(in) :: boundary_left, boundary_right
     integer(ik), intent(in) :: neven
     real(rk), intent(out) :: sub(:,:,:,:) ! (ngroup,ngroup,nx-1,neven)
     real(rk), intent(out) :: dia(:,:,:,:) ! (ngroup,ngroup,nx,neven)
@@ -102,8 +102,18 @@ contains
       call inv(xslib%ngroup, anext(:,:,myid), matinv(:,:,myid))
       anext(:,:,myid) = 2.0_rk/dx(1)/dx(2) &
         * matmul(matmul(dhat_this(:,:,myid), matinv(:,:,myid)), dhat_next(:,:,myid))
-      dia(:,:,1,n) = anext(:,:,myid)
-      sup(:,:,1,n) = -anext(:,:,myid)
+      select case (boundary_left)
+        case ('mirror')
+          dia(:,:,1,n) = anext(:,:,myid)
+          sup(:,:,1,n) = -anext(:,:,myid)
+        case ('zero')
+          dia(:,:,1,n) = anext(:,:,myid) + 2 * dhat_this(:,:,myid)/dx(1)
+          sup(:,:,1,n) = -anext(:,:,myid)
+        case default
+          call exception_fatal(&
+            'unknown boundary_left in transport_block_build_matrix: ' &
+            // trim(adjustl(boundary_left)))
+      endselect
     enddo ! n = 1,neven
 
     !$omp parallel do default(none) &
@@ -186,7 +196,9 @@ contains
           sub(:,:,nx-1,n) = -aprev(:,:,myid)
           dia(:,:,nx,n) = aprev(:,:,myid) + 2 * dhat_this(:,:,myid)/dx(nx)
         case default
-          call exception_fatal('unknown boundary_right: ' // trim(adjustl(boundary_right)))
+          call exception_fatal(&
+            'unknown boundary_right in transport_block_build_matrix: ' &
+            // trim(adjustl(boundary_right)))
       endselect
     enddo ! n = 1,neven
 
@@ -210,7 +222,8 @@ contains
   endsubroutine transport_block_build_matrix
 
   subroutine transport_block_build_next_source(&
-    nx, dx, mat_map, xslib, boundary_right, neven, phi_block, pn_next_source)
+    nx, dx, mat_map, xslib, boundary_left, boundary_right, &
+    neven, phi_block, pn_next_source)
     use xs, only : XSLibrary
     use linalg, only : inv
     use omp_lib, only : omp_get_num_threads, omp_get_thread_num
@@ -219,7 +232,7 @@ contains
     real(rk), intent(in) :: dx(:) ! (nx)
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     type(XSLibrary), intent(in) :: xslib
-    character(*), intent(in) :: boundary_right
+    character(*), intent(in) :: boundary_left, boundary_right
     integer(ik), intent(in) :: neven
     real(rk), intent(in) :: phi_block(:,:,:) ! (ngroup,nx,pnorder+1)
     real(rk), intent(out) :: pn_next_source(:,:,:) ! (ngroup,nx,neven)
@@ -267,8 +280,19 @@ contains
       call inv(xslib%ngroup, bnext(:,:,myid), matinv(:,:,myid))
       bnext(:,:,myid) = 2.0_rk/dx(1)/dx(2) &
         * matmul(matmul(fhat_this(:,:,myid), matinv(:,:,myid)), fhat_next(:,:,myid))
-      pn_next_source(:,1,n) = -matmul(bnext(:,:,myid), phi_block(:,1,idxn+1+2)) &
-        + matmul(bnext(:,:,myid), phi_block(:,2,idxn+1+2))
+      select case (boundary_left)
+        case ('mirror')
+          pn_next_source(:,1,n) = -matmul(bnext(:,:,myid), phi_block(:,1,idxn+1+2)) &
+            + matmul(bnext(:,:,myid), phi_block(:,2,idxn+1+2))
+        case ('zero')
+          pn_next_source(:,1,n) = -matmul(bnext(:,:,myid), phi_block(:,1,idxn+1+2)) &
+            + matmul(bnext(:,:,myid), phi_block(:,2,idxn+1+2)) &
+            - 2.0_rk/dx(1) * matmul(fhat_this(:,:,myid), phi_block(:,1,idxn+1+2))
+        case default
+          call exception_fatal(&
+            'unknown boundary_left in transport_block_build_next_source: ' &
+            // trim(adjustl(boundary_left)))
+      endselect
     enddo ! n = 1,neven-1
 
     !$omp parallel do default(none) &
@@ -333,7 +357,8 @@ contains
             - 2.0_rk/dx(nx) * matmul(fhat_this(:,:,myid), phi_block(:,nx,idxn+1+2))
         case default
           call exception_fatal(&
-            'unknown boundary_right in next_source: ' // trim(adjustl(boundary_right)))
+            'unknown boundary_right in transport_block_build_next_source: ' &
+            // trim(adjustl(boundary_right)))
       endselect
     enddo ! n = 1,neven
 
@@ -343,7 +368,8 @@ contains
   endsubroutine transport_block_build_next_source
 
   subroutine transport_block_build_prev_source( &
-    nx, dx, mat_map, xslib, boundary_right, idxn, phi_block, pn_prev_source)
+    nx, dx, mat_map, xslib, boundary_left, boundary_right, &
+    idxn, phi_block, pn_prev_source)
     use xs, only : XSLibrary
     use linalg, only : inv
     use omp_lib, only : omp_get_num_threads, omp_get_thread_num
@@ -352,7 +378,7 @@ contains
     real(rk), intent(in) :: dx(:) ! (nx)
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     type(XSLibrary), intent(in) :: xslib
-    character(*), intent(in) :: boundary_right
+    character(*), intent(in) :: boundary_left, boundary_right
     integer(ik), intent(in) :: idxn
     real(rk), intent(in) :: phi_block(:,:,:) ! (ngroup,nx,pnorder+1)
     real(rk), intent(out) :: pn_prev_source(:,:) ! (ngroup,nx)
@@ -402,8 +428,19 @@ contains
     call inv(xslib%ngroup, cnext(:,:,myid), matinv(:,:,myid))
     cnext(:,:,myid) = 2.0_rk/dx(1)/dx(2) &
       * matmul(matmul(ghat_this(:,:,myid), matinv(:,:,myid)), ghat_next(:,:,myid))
-    pn_prev_source(:,1) = -matmul(cnext(:,:,myid), phi_block(:,1,idxn+1-2)) &
-      + matmul(cnext(:,:,myid), phi_block(:,2,idxn+1-2))
+    select case (boundary_left)
+      case ('mirror')
+        pn_prev_source(:,1) = -matmul(cnext(:,:,myid), phi_block(:,1,idxn+1-2)) &
+          + matmul(cnext(:,:,myid), phi_block(:,2,idxn+1-2))
+      case ('zero')
+        pn_prev_source(:,1) = -matmul(cnext(:,:,myid), phi_block(:,1,idxn+1-2)) &
+          + matmul(cnext(:,:,myid), phi_block(:,2,idxn+1-2)) &
+          - 2.0_rk/dx(1) * matmul(ghat_this(:,:,myid), phi_block(:,1,idxn+1-2))
+      case default
+        call exception_fatal(&
+          'unknown boundary_left in transport_block_build_prev_source: ' &
+          // trim(adjustl(boundary_left)))
+    endselect
 
     !$omp parallel do default(none) &
     !$omp shared (nx) &
@@ -458,7 +495,8 @@ contains
           - 2.0_rk/dx(nx) * matmul(ghat_this(:,:,myid), phi_block(:,nx,idxn+1-2))
       case default
         call exception_fatal( &
-          'unknown boundary_right in prev_source: ' // trim(adjustl(boundary_right)))
+          'unknown boundary_right in transport_block_build_prev_source: ' &
+          // trim(adjustl(boundary_right)))
     endselect
 
     deallocate(matinv)
@@ -510,7 +548,8 @@ contains
   endfunction transport_block_fission_summation
 
   subroutine transport_block_power_iteration(&
-    nx, dx, mat_map, xslib, boundary_right, calc_type, k_tol, phi_tol, max_iter, pnorder, keff, sigma_tr, phi)
+    nx, dx, mat_map, xslib, boundary_left, boundary_right, &
+    calc_type, k_tol, phi_tol, max_iter, pnorder, keff, sigma_tr, phi)
     use xs, only : XSLibrary
     use linalg, only : trid_block
     use output, only : output_write
@@ -520,7 +559,7 @@ contains
     real(rk), intent(in) :: dx(:) ! (nx)
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     type(XSLibrary), intent(in) :: xslib
-    character(*), intent(in) :: boundary_right
+    character(*), intent(in) :: boundary_left, boundary_right
     character(*), intent(in) :: calc_type
     real(rk), intent(in) :: k_tol, phi_tol
     integer(ik), intent(in) :: max_iter
@@ -588,7 +627,8 @@ contains
 
     call output_write('  building transport matrix')
     call timer_start('transport_build_matrix')
-    call transport_block_build_matrix(nx, dx, mat_map, xslib, boundary_right, neven, sub, dia, sup)
+    call transport_block_build_matrix(nx, dx, mat_map, xslib, &
+      boundary_left, boundary_right, neven, sub, dia, sup)
     call timer_stop('transport_build_matrix')
 
     if (calc_type == 'fixed_source') then
@@ -608,7 +648,8 @@ contains
 
       call timer_start('transport_pn_source')
       call transport_block_build_next_source( &
-        nx, dx, mat_map, xslib, boundary_right, neven, phi_block, pn_next_source)
+        nx, dx, mat_map, xslib, boundary_left, boundary_right, &
+        neven, phi_block, pn_next_source)
       call timer_stop('transport_pn_source')
 
       do n = 1,neven
@@ -631,7 +672,8 @@ contains
         else
           call timer_start('transport_pn_source')
           call transport_block_build_prev_source( &
-            nx, dx, mat_map, xslib, boundary_right, idxn, phi_block, pn_prev_source)
+            nx, dx, mat_map, xslib, boundary_left, boundary_right, &
+            idxn, phi_block, pn_prev_source)
           q = q + pn_prev_source
           call timer_stop('transport_pn_source')
         endif
@@ -677,7 +719,8 @@ contains
     endif
 
     call timer_start('calc_odd')
-    call transport_block_calc_odd(nx, dx, mat_map, xslib, boundary_right, pnorder, phi_block)
+    call transport_block_calc_odd(nx, dx, mat_map, xslib, &
+      boundary_left, boundary_right, pnorder, phi_block)
     call timer_stop('calc_odd')
     call timer_start('calc_transportxs')
     call transport_block_calc_transportxs(nx, mat_map, xslib, pnorder, phi_block, sigma_tr)
@@ -699,7 +742,8 @@ contains
     deallocate(sub_copy, dia_copy, sup_copy)
   endsubroutine transport_block_power_iteration
 
-  subroutine transport_block_calc_odd(nx, dx, mat_map, xslib, boundary_right, pnorder, phi_block)
+  subroutine transport_block_calc_odd(nx, dx, mat_map, xslib, &
+      boundary_left, boundary_right, pnorder, phi_block)
     use xs, only : XSLibrary
     use numeric, only : deriv
     use exception_handler, only : exception_fatal
@@ -707,7 +751,7 @@ contains
     real(rk), intent(in) :: dx(:) ! (nx)
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     type(XSLibrary), intent(in) :: xslib
-    character(*), intent(in) :: boundary_right
+    character(*), intent(in) :: boundary_left, boundary_right
     integer(ik), intent(in) :: pnorder
     real(rk), intent(inout) :: phi_block(:,:,:) ! (ngroup,nx,pnorder+1)
 
@@ -779,22 +823,42 @@ contains
       ! BC at x=0, i=1
       ! use the fact that odd moments must equal zero for mirror bc
       ! this stencil kind of extends to x3 because phi(2) was computed earlier
-      phi_block(:,1,idxn+1) = phi_block(:,2,idxn+1) &
-        * 0.5_rk * dx(1) / (dx(1) + 0.5_rk*dx(2))
+      select case (boundary_left)
+        case ('mirror')
+          phi_block(:,1,idxn+1) = phi_block(:,2,idxn+1) &
+            * 0.5_rk * dx(1) / (dx(1) + 0.5_rk*dx(2))
+        case ('zero')
+          dphi_prev = -phi_block(:,2,idxn+1-1)/(dx(1) + 0.5_rk*dx(2))
+          if (n < pnorder + 1) then
+            dphi_next = -phi_block(:,2,idxn+1+1)/(dx(1) + 0.5_rk*dx(2))
+          else
+            dphi_next = 0.0_rk
+          endif
+          call transport_invtransmat(xslib%mat(mat_map(1)), idxn, trans)
+          phi_block(:,1,idxn+1) = matmul(trans, xmul_next * dphi_next + xmul_prev * dphi_prev)
+        case default
+          call exception_fatal(&
+            'unknown boundary_left in transport_block_calc_odd: ' &
+            // trim(adjustl(boundary_left)))
+      endselect
       ! BC at x=L, i=N
       select case (boundary_right)
         case ('mirror')
           phi_block(:,nx,idxn+1) = phi_block(:,nx-1,idxn+1) &
             * 0.5_rk * dx(nx) / (dx(nx) + 0.5_rk*dx(nx-1))
         case ('zero')
-          dphi_prev = -phi_block(:,nx-1,idxn+1-1)/(dx(nx) + 0.5_rk*(dx(nx-1)))
+          dphi_prev = -phi_block(:,nx-1,idxn+1-1)/(dx(nx) + 0.5_rk*dx(nx-1))
           if (n < pnorder + 1) then
-            dphi_next = -phi_block(:,nx-1,idxn+1+1)/(dx(nx) + 0.5_rk*(dx(nx-1)))
+            dphi_next = -phi_block(:,nx-1,idxn+1+1)/(dx(nx) + 0.5_rk*dx(nx-1))
+          else
+            dphi_next = 0.0_rk
           endif
           call transport_invtransmat(xslib%mat(mat_map(nx)), idxn, trans)
           phi_block(:,nx,idxn+1) = -matmul(trans, xmul_next * dphi_next + xmul_prev * dphi_prev)
         case default
-          call exception_fatal('unknown boundary in odd_update: ' // trim(adjustl(boundary_right)))
+          call exception_fatal(&
+            'unknown boundary_right in transport_block_calc_odd: ' &
+            // trim(adjustl(boundary_right)))
       endselect
     enddo
 


### PR DESCRIPTION
Support zero-flux boundary conditions on the right-hand side.

This is implemented in `diffusion`, `diffusion_block`, `transport`, and `transport_block`.

I also included some code cleanup to remove repeated code.

Resolves #28 