### PR TITLE
Support Albedo BCs for diffusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(${PROJECT_NAME}.x)
 
 target_sources(${PROJECT_NAME}.x
   PRIVATE
+    src/albedo.f90
     src/analytic.f90
     src/constant.f90
     src/diffusion_block.f90

--- a/cases/albedo/albedo.inp
+++ b/cases/albedo/albedo.inp
@@ -4,7 +4,7 @@ dx 10. 10. 10. 10. 10.
 mat_map FUEL FUEL FUEL FUEL FUEL
 refine 4
 boundary_right albedo
-# pseud-vacuum condition
+# pseudo-vacuum condition
 albedo 0.0
 k_tol 1e-10
 phi_tol 1e-9

--- a/cases/albedo/albedo.inp
+++ b/cases/albedo/albedo.inp
@@ -1,0 +1,13 @@
+xslib_fname onegroup.xs
+nx 5
+dx 10. 10. 10. 10. 10.
+mat_map FUEL FUEL FUEL FUEL FUEL
+refine 4
+boundary_right albedo
+# pseud-vacuum condition
+albedo 0.0
+k_tol 1e-10
+phi_tol 1e-9
+max_iter 1000
+pnorder 0
+analytic_reference albedo

--- a/cases/albedo/doit.py
+++ b/cases/albedo/doit.py
@@ -1,0 +1,119 @@
+import numpy as np
+import subprocess
+import matplotlib
+import matplotlib.pyplot as plt
+import sys
+
+matplotlib.rcParams["lines.linewidth"] = 2
+# matplotlib.rcParams["mathtext.fontset"] = "stix"
+# matplotlib.rcParams["font.family"] = "STIXGeneral"
+matplotlib.rcParams["font.size"] = 16
+
+
+def set_input(txt, pnorder, refine):
+    out = []
+    for line in txt:
+        if "refine" in line:
+            out.append("refine {:d}\n".format(refine))
+        elif "pnorder" in line:
+            out.append("pnorder {:d}\n".format(pnorder))
+        else:
+            out.append(line)
+    return out
+
+
+def run(exe, inp):
+    result = subprocess.run([exe, inp], stdout=subprocess.PIPE)
+    return result.stdout.decode("utf-8")
+
+
+def get_keyword(lines, keyword):
+    for line in lines:
+        if keyword + " = " in line:
+            line = line.split()
+            return float(line[2])
+
+
+def get_keff(lines):
+    return get_keyword(lines, "keff")
+
+
+def get_nx(lines):
+    ready = False
+    for line in lines:
+        if "after refinement" in line:
+            ready = True
+        elif "nx =" in line:
+            nx = int(line.split()[2])
+            if ready:
+                return nx
+    # in case refinement not performed
+    return nx
+
+
+if __name__ == "__main__":
+
+    executable = "../../build/siren.x"
+    fname_base = "albedo.inp"
+    max_refine = 9
+
+    fname_run = fname_base.replace(".inp", "_run.inp")
+
+    runtxt = open(fname_base, "r").readlines()
+
+    linferr = np.zeros((max_refine, 1))
+    keff_diff = np.zeros(max_refine)
+    nx = np.zeros(max_refine, dtype=int)
+
+    p = 0
+    for r in range(0, max_refine):
+        inp = set_input(runtxt, p, r)
+        open(fname_run, "w").writelines(inp)
+
+        out = run(executable, fname_run)
+        if "CONVERGENCE!" not in out:
+            print("failed to converge p=", p, "r=", r)
+            sys.exit(1)
+        out = out.split("\n")
+
+        keff = get_keff(out)
+        keff_diff[r] = get_keyword(out, "keff_diff")
+
+        for n in range(linferr.shape[1]):
+            linferr[r, n] = get_keyword(out, "linferr_n{:d}_g1".format(n))
+
+        nx[r] = get_nx(out)
+
+        print("p=", p, "r=", r, "keff= {:.16f}".format(keff))
+
+    with open("result.csv", "w") as f:
+        f.write(" , keff_diff [pcm]")
+        for n in range(linferr.shape[1]):
+            f.write(" , linferr_n{:d}_g1".format(n))
+        f.write("\n")
+        for ridx in range(max_refine):
+            f.write("r{:d}".format(ridx))
+            f.write(" , {:.16f}".format(keff_diff[ridx]))
+            for n in range(linferr.shape[1]):
+                f.write(" , {:.16e}".format(linferr[ridx, n]))
+            f.write("\n")
+
+    plt.figure()
+    plt.loglog(nx, np.abs(keff_diff), "-o")
+    plt.loglog(nx, np.abs(keff_diff[0]) / nx[0] / nx**2, "-k", lw=1, label="_hide")
+    plt.xlabel("NX")
+    plt.ylabel("keff error [pcm]")
+    plt.title("Spatial Refinement")
+    plt.tight_layout()
+
+    plt.figure()
+    for n in range(linferr.shape[1]):
+        plt.loglog(nx, linferr[:, n], "-o", label="$\\phi_{{{:d}}}$".format(n))
+    plt.loglog(nx, np.abs(linferr[0, 0]) / nx[0] / nx**2, "-k", lw=1, label="_hide")
+    plt.legend()
+    plt.xlabel("NX")
+    plt.ylabel("$\\| \\phi_n \\|$")
+    plt.title("Spatial Refinement")
+    plt.tight_layout()
+
+    plt.show()

--- a/cases/albedo/onegroup.xs
+++ b/cases/albedo/onegroup.xs
@@ -1,0 +1,19 @@
+niso 1
+ngroup 1
+nmoment 1
+
+name FUEL
+diffusion
+3.333333E+00
+sigma_t
+1.000000E-01
+sigma_f
+4.000000E-03
+sigma_a
+7.000000E-03
+nusf
+1.000000E-02
+chi
+1.000000E+00
+scatter 0
+9.300000E-02

--- a/cases/analytic_p3/analytic_p3.inp
+++ b/cases/analytic_p3/analytic_p3.inp
@@ -5,7 +5,7 @@ mat_map FUEL FUEL FUEL FUEL FUEL
 xslib_fname benchmark_new.xs
 
 refine 5
-pnorder 3
+pnorder 7
 
 k_tol 1d-10
 phi_tol 1e-9
@@ -13,4 +13,4 @@ max_iter 1000
 
 boundary_right zero
 
-analytic_reference analytic_p3
+analytic_reference analytic_pn

--- a/src/albedo.f90
+++ b/src/albedo.f90
@@ -4,22 +4,20 @@ implicit none
 
 private
 
-public :: albedo_calculate_alpha, albedo_calculate_dstar
+public :: albedo_calculate_alpha
 
 contains
 
   real(rk) pure function albedo_calculate_alpha(a)
     real(rk), intent(in) :: a
-    albedo_calculate_alpha = 0.5_rk * (1.0_rk - a) / (1.0_rk + a)
+    real(rk), parameter :: albedo_max = 1e6_rk
+    if (abs(1.0_rk + a) < 1e-8_rk) then
+      albedo_calculate_alpha = albedo_max
+    else
+      albedo_calculate_alpha = 0.5_rk * (1.0_rk - a) / (1.0_rk + a)
+    endif
     ! use some filtering to protect from numerical issues for vacuum bc
-    albedo_calculate_alpha = min(albedo_calculate_alpha, 1e3_rk)
+    albedo_calculate_alpha = min(albedo_calculate_alpha, albedo_max)
   endfunction albedo_calculate_alpha
-
-  real(rk) pure function albedo_calculate_dstar(diffusion, alpha)
-    real(rk), intent(in) :: diffusion ! diffusion coefficient [cm]
-    real(rk), intent(in) :: alpha ! alpha albedo coefficient
-    ! NOTE the input to this function is an alpha! Not a "big-A".
-    albedo_calculate_dstar = diffusion / alpha
-  endfunction albedo_calculate_dstar
 
 endmodule albedo

--- a/src/albedo.f90
+++ b/src/albedo.f90
@@ -1,0 +1,25 @@
+module albedo
+use kind, only : rk
+implicit none
+
+private
+
+public :: albedo_calculate_alpha, albedo_calculate_dstar
+
+contains
+
+  real(rk) pure function albedo_calculate_alpha(a)
+    real(rk), intent(in) :: a
+    albedo_calculate_alpha = 0.5_rk * (1.0_rk - a) / (1.0_rk + a)
+    ! use some filtering to protect from numerical issues for vacuum bc
+    albedo_calculate_alpha = min(albedo_calculate_alpha, 1e3_rk)
+  endfunction albedo_calculate_alpha
+
+  real(rk) pure function albedo_calculate_dstar(diffusion, alpha)
+    real(rk), intent(in) :: diffusion ! diffusion coefficient [cm]
+    real(rk), intent(in) :: alpha ! alpha albedo coefficient
+    ! NOTE the input to this function is an alpha! Not a "big-A".
+    albedo_calculate_dstar = diffusion / alpha
+  endfunction albedo_calculate_dstar
+
+endmodule albedo

--- a/src/analytic.f90
+++ b/src/analytic.f90
@@ -16,10 +16,14 @@ real(rk), parameter :: Lr_tworeg = 100.0_rk
 ! analytic p3
 real(rk), parameter :: Lx_p3 = 1e2_rk
 
+! albedo
+! LF = 50 cm (with mirror, so buckling length is 100 cm)
+real(rk), parameter :: B_albedo = 0.02775645888894529358936758001164_rk ! [1/cm]
+
 contains
 
   subroutine analytic_error(analytic_name, fname, &
-      nx, ngroup, pnorder, xslib, dx, phi, keff, albedo_coeff)
+      nx, ngroup, pnorder, xslib, dx, phi, keff)
     use xs, only : XSLibrary
     use linalg, only : norm
     use output, only : output_write
@@ -31,7 +35,6 @@ contains
     real(rk), intent(in) :: dx(:)
     real(rk), intent(in) :: phi(:,:,:) ! (nx,ngroup,pnorder+1)
     real(rk), intent(in) :: keff
-    real(rk), intent(in) :: albedo_coeff
 
     ! assume that the coordinate system starts at xleft==0.0
     ! we don't really know in general since all we have are deltas
@@ -80,7 +83,7 @@ contains
       case ('analytic_pn')
         call analytic_fun_pn(x, xslib, phi_exact)
       case ('albedo')
-        call analytic_fun_albedo(x, xslib, albedo_coeff, phi_exact)
+        call analytic_fun_albedo(x, phi_exact)
       case default
         call exception_fatal('unknown analytic_name: ' // trim(adjustl(analytic_name)))
     endselect
@@ -109,7 +112,7 @@ contains
       case ('analytic_pn')
         call analytic_fun_pn(x, xslib, phi_exact, keff_exact)
       case ('albedo')
-        keff_exact = analytic_keff_albedo(xslib, albedo_coeff)
+        keff_exact = analytic_keff_albedo(xslib)
       case default
         call exception_fatal('second -- unknown analytic_name: ' // trim(adjustl(analytic_name)))
     endselect
@@ -452,12 +455,12 @@ contains
 
       if ((idxn - 1) > 0) then
         Pmat = xidxn*(xidxn-1.0_rk)/((2.0_rk*xidxn+1.0_rk)*(2.0_rk*xidxn-1.0_rk))*inv_removal(:,:,idxn+1-1)
-        Phat(lo:hi,xsmat%ngroup*(n-2)+1:xsmat%ngroup*(n-1)) = Pmat ! TODO transpose block?
+        Phat(lo:hi,xsmat%ngroup*(n-2)+1:xsmat%ngroup*(n-1)) = Pmat
       endif
 
       if ((idxn + 1) < pnorder-1) then
         Nmat = (xidxn+1.0_rk)*(xidxn+2.0_rk)/((2.0_rk*xidxn+1.0_rk)*(2.0_rk*xidxn+3.0_rk))*inv_removal(:,:,idxn+1+1)
-        Nhat(lo:hi,xsmat%ngroup*n+1:xsmat%ngroup*(n+1)) = Nmat ! TODO transpose block?
+        Nhat(lo:hi,xsmat%ngroup*n+1:xsmat%ngroup*(n+1)) = Nmat
       endif
 
     enddo ! n = 1,neq
@@ -587,36 +590,21 @@ contains
     deallocate(a, f)
   endsubroutine analytic_fun_pn
 
-  subroutine analytic_fun_albedo(x, xslib, albedo_coeff, exact)
+  subroutine analytic_fun_albedo(x, exact)
     use xs, only : XSLibrary
-    use albedo, only : albedo_calculate_alpha, albedo_calculate_dstar
-    use constant, only : pi
     real(rk), intent(in) :: x(:)
-    type(XSLibrary), intent(in) :: xslib
-    real(rk), intent(in) :: albedo_coeff
     real(rk), intent(out) :: exact(:,:,:)
     real(rk), parameter :: phi0 = 1.0_rk
-    real(rk) :: alpha, dstar, buckle
-    alpha = albedo_calculate_alpha(albedo_coeff)
-    dstar = albedo_calculate_dstar(xslib%mat(1)%diffusion(1), alpha)
-    buckle = pi / (Lx_twogroup + 2.0_rk * dstar)
-    exact(:,1,1) = phi0 * cos(buckle * x)
+    exact(:,1,1) = phi0 * cos(B_albedo * x)
   endsubroutine analytic_fun_albedo
 
-  real(rk) pure function analytic_keff_albedo(xslib, albedo_coeff)
+  real(rk) pure function analytic_keff_albedo(xslib)
     use xs, only : XSLibrary
-    use constant, only : pi
-    use albedo, only : albedo_calculate_alpha, albedo_calculate_dstar
     type(XSLibrary), intent(in) :: xslib
-    real(rk), intent(in) :: albedo_coeff
-    real(rk) :: bsq, rem
-    real(rk) :: alpha, dstar
+    real(rk) :: rem
     rem = xslib%mat(1)%sigma_t(1) - xslib%mat(1)%scatter(1,1,1)
-    alpha = albedo_calculate_alpha(albedo_coeff)
-    dstar = albedo_calculate_dstar(xslib%mat(1)%diffusion(1), alpha)
-    bsq = (pi / (Lx_twogroup + 2*dstar))**2
     analytic_keff_albedo = xslib%mat(1)%nusf(1) & 
-      / (xslib%mat(1)%diffusion(1) * bsq + rem)
+      / (xslib%mat(1)%diffusion(1) * B_albedo**2 + rem)
   endfunction analytic_keff_albedo
 
 endmodule analytic

--- a/src/analytic.f90
+++ b/src/analytic.f90
@@ -18,7 +18,8 @@ real(rk), parameter :: Lx_p3 = 1e2_rk
 
 contains
 
-  subroutine analytic_error(analytic_name, fname, nx, ngroup, pnorder, xslib, dx, phi, keff)
+  subroutine analytic_error(analytic_name, fname, &
+      nx, ngroup, pnorder, xslib, dx, phi, keff, albedo_coeff)
     use xs, only : XSLibrary
     use linalg, only : norm
     use output, only : output_write
@@ -30,6 +31,7 @@ contains
     real(rk), intent(in) :: dx(:)
     real(rk), intent(in) :: phi(:,:,:) ! (nx,ngroup,pnorder+1)
     real(rk), intent(in) :: keff
+    real(rk), intent(in) :: albedo_coeff
 
     ! assume that the coordinate system starts at xleft==0.0
     ! we don't really know in general since all we have are deltas
@@ -77,6 +79,8 @@ contains
         call analytic_fun_p3(x, xslib, phi_exact)
       case ('analytic_pn')
         call analytic_fun_pn(x, xslib, phi_exact)
+      case ('albedo')
+        call analytic_fun_albedo(x, xslib, albedo_coeff, phi_exact)
       case default
         call exception_fatal('unknown analytic_name: ' // trim(adjustl(analytic_name)))
     endselect
@@ -104,6 +108,8 @@ contains
         keff_exact = analytic_keff_p3(xslib)
       case ('analytic_pn')
         call analytic_fun_pn(x, xslib, phi_exact, keff_exact)
+      case ('albedo')
+        keff_exact = analytic_keff_albedo(xslib, albedo_coeff)
       case default
         call exception_fatal('second -- unknown analytic_name: ' // trim(adjustl(analytic_name)))
     endselect
@@ -580,5 +586,37 @@ contains
     deallocate(amplitude)
     deallocate(a, f)
   endsubroutine analytic_fun_pn
+
+  subroutine analytic_fun_albedo(x, xslib, albedo_coeff, exact)
+    use xs, only : XSLibrary
+    use albedo, only : albedo_calculate_alpha, albedo_calculate_dstar
+    use constant, only : pi
+    real(rk), intent(in) :: x(:)
+    type(XSLibrary), intent(in) :: xslib
+    real(rk), intent(in) :: albedo_coeff
+    real(rk), intent(out) :: exact(:,:,:)
+    real(rk), parameter :: phi0 = 1.0_rk
+    real(rk) :: alpha, dstar, buckle
+    alpha = albedo_calculate_alpha(albedo_coeff)
+    dstar = albedo_calculate_dstar(xslib%mat(1)%diffusion(1), alpha)
+    buckle = pi / (Lx_twogroup + 2.0_rk * dstar)
+    exact(:,1,1) = phi0 * cos(buckle * x)
+  endsubroutine analytic_fun_albedo
+
+  real(rk) pure function analytic_keff_albedo(xslib, albedo_coeff)
+    use xs, only : XSLibrary
+    use constant, only : pi
+    use albedo, only : albedo_calculate_alpha, albedo_calculate_dstar
+    type(XSLibrary), intent(in) :: xslib
+    real(rk), intent(in) :: albedo_coeff
+    real(rk) :: bsq, rem
+    real(rk) :: alpha, dstar
+    rem = xslib%mat(1)%sigma_t(1) - xslib%mat(1)%scatter(1,1,1)
+    alpha = albedo_calculate_alpha(albedo_coeff)
+    dstar = albedo_calculate_dstar(xslib%mat(1)%diffusion(1), alpha)
+    bsq = (pi / (Lx_twogroup + 2*dstar))**2
+    analytic_keff_albedo = xslib%mat(1)%nusf(1) & 
+      / (xslib%mat(1)%diffusion(1) * bsq + rem)
+  endfunction analytic_keff_albedo
 
 endmodule analytic

--- a/src/diffusion.f90
+++ b/src/diffusion.f90
@@ -11,7 +11,8 @@ public :: diffusion_build_matrix, diffusion_build_fsource, &
 contains
 
   subroutine diffusion_build_matrix(nx, dx, mat_map, xslib, &
-      boundary_left, boundary_right, sub, dia, sup, diffusion_coeff)
+      boundary_left, boundary_right, albedo_alpha, &
+      sub, dia, sup, diffusion_coeff)
     use xs, only : XSLibrary
     use exception_handler, only : exception_fatal
     integer(ik), intent(in) :: nx
@@ -19,6 +20,7 @@ contains
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     type(XSLibrary), intent(in) :: xslib
     character(*), intent(in) :: boundary_left, boundary_right
+    real(rk), intent(in) :: albedo_alpha
     real(rk), intent(out) :: sub(:,:) ! (nx,ngroup)
     real(rk), intent(out) :: dia(:,:) ! (nx,ngroup)
     real(rk), intent(out) :: sup(:,:) ! (nx,ngroup)
@@ -116,6 +118,10 @@ contains
         case ('mirror')
           dia(nx,g) = dprev &
             + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(nx)
+        case ('albedo')
+          dia(nx,g) = dprev &
+            + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(nx) &
+            + 1.0_rk / (1.0_rk / albedo_alpha + 0.5_rk * dx(nx) / xslib%mat(mthis)%diffusion(g))
         case default
           call exception_fatal(&
             'unknown boundary_right in diffusion_build_matrix: '&
@@ -212,18 +218,20 @@ contains
   endfunction diffusion_fission_summation
 
   subroutine diffusion_power_iteration( &
-    nx, dx, mat_map, xslib, boundary_left, boundary_right, &
+    nx, dx, mat_map, xslib, boundary_left, boundary_right, albedo_coeff, &
     k_tol, phi_tol, max_iter, keff, flux, transportxs)
     use xs, only : XSLibrary
     use linalg, only : trid
     use output, only : output_write
     use timer, only : timer_start, timer_stop
     use exception_handler, only : exception_warning
+    use albedo, only : albedo_calculate_alpha
     integer(ik), intent(in) :: nx
     real(rk), intent(in) :: dx(:) ! (nx)
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     type(XSLibrary), intent(in) :: xslib
     character(*), intent(in) :: boundary_left, boundary_right
+    real(rk), intent(in) :: albedo_coeff ! A \in [-1,1]
     real(rk), intent(in) :: k_tol, phi_tol
     integer(ik), intent(in) :: max_iter
     real(rk), intent(out) :: keff
@@ -240,6 +248,7 @@ contains
     real(rk) :: k_old, fsum, fsum_old
     real(rk), allocatable :: flux_old(:,:)
     real(rk) :: delta_k, delta_phi
+    real(rk) :: albedo_alpha ! \alpha \in [0, \infty)
 
     real(rk), allocatable :: diffusion_coeff(:,:) ! (nx,ngroup)
 
@@ -255,13 +264,15 @@ contains
       call diffusion_populate_coeff(nx, mat_map, xslib, transportxs, diffusion_coeff)
     endif
 
+    albedo_alpha = albedo_calculate_alpha(albedo_coeff)
     call timer_start('diffusion_build_matrix')
     if (allocated(diffusion_coeff)) then
       call diffusion_build_matrix(nx, dx, mat_map, xslib, &
-        boundary_left, boundary_right, sub, dia, sup, diffusion_coeff)
+        boundary_left, boundary_right, albedo_alpha, &
+        sub, dia, sup, diffusion_coeff)
     else
       call diffusion_build_matrix(nx, dx, mat_map, xslib, &
-        boundary_left, boundary_right, sub, dia, sup)
+        boundary_left, boundary_right, albedo_alpha, sub, dia, sup)
       if (matrix_dump) then
         write(730, '(es13.6,",",es13.6,",",es13.6)') 0d0 , dia(1,1), sup(1,1)
         do i = 2,nx-1

--- a/src/diffusion.f90
+++ b/src/diffusion.f90
@@ -54,6 +54,16 @@ contains
           endif
         case ('mirror')
           dia(1,g) = dnext + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(1)
+        case ('albedo')
+          if (present(diffusion_coeff)) then
+            dia(1,g) = dnext &
+              + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(1) &
+              + 1.0_rk / (1.0_rk / albedo_alpha + 0.5_rk * dx(1) / diffusion_coeff(1,g))
+          else
+            dia(1,g) = dnext &
+              + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(1) &
+              + 1.0_rk / (1.0_rk / albedo_alpha + 0.5_rk * dx(1) / xslib%mat(mthis)%diffusion(g))
+          endif
         case default
           call exception_fatal(&
             'unknown boundary_left in diffusion_build_matrix: '&
@@ -119,9 +129,15 @@ contains
           dia(nx,g) = dprev &
             + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(nx)
         case ('albedo')
-          dia(nx,g) = dprev &
-            + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(nx) &
-            + 1.0_rk / (1.0_rk / albedo_alpha + 0.5_rk * dx(nx) / xslib%mat(mthis)%diffusion(g))
+          if (present(diffusion_coeff)) then
+            dia(nx,g) = dprev &
+              + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(nx) &
+              + 1.0_rk / (1.0_rk / albedo_alpha + 0.5_rk * dx(nx) / diffusion_coeff(nx,g))
+          else
+            dia(nx,g) = dprev &
+              + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(nx) &
+              + 1.0_rk / (1.0_rk / albedo_alpha + 0.5_rk * dx(nx) / xslib%mat(mthis)%diffusion(g))
+          endif
         case default
           call exception_fatal(&
             'unknown boundary_right in diffusion_build_matrix: '&

--- a/src/diffusion_block.f90
+++ b/src/diffusion_block.f90
@@ -43,6 +43,9 @@ contains
             + 2 * xslib%mat(mthis)%diffusion(g)/dx(1)
         case ('mirror')
           dia(g,g,1) = dnext + xslib%mat(mthis)%sigma_t(g) * dx(1)
+        case ('albedo')
+          dia(g,g,1) = dnext + xslib%mat(mthis)%sigma_t(g) * dx(1) &
+            + 1.0_rk / (1.0_rk / albedo_alpha + 0.5_rk * dx(1) / xslib%mat(mthis)%diffusion(g))
         case default
           call exception_fatal(&
             'unknown boundary_left in diffusion_block_build_matrix: ' &

--- a/src/diffusion_block.f90
+++ b/src/diffusion_block.f90
@@ -8,7 +8,7 @@ public :: diffusion_block_power_iteration
 contains
 
   subroutine diffusion_block_build_matrix(nx, dx, mat_map, xslib, &
-      boundary_left, boundary_right, sub, dia, sup)
+      boundary_left, boundary_right, albedo_alpha, sub, dia, sup)
     use xs, only : XSLibrary
     use exception_handler, only : exception_fatal
     integer(ik), intent(in) :: nx
@@ -16,6 +16,7 @@ contains
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     type(XSLibrary), intent(in) :: xslib
     character(*), intent(in) :: boundary_left, boundary_right
+    real(rk), intent(in) :: albedo_alpha ! \alpha \in [0,\infty)
     real(rk), intent(out) :: sub(:,:,:) ! (ngroup,ngroup,nx-1)
     real(rk), intent(out) :: dia(:,:,:) ! (ngroup,ngroup,nx)
     real(rk), intent(out) :: sup(:,:,:) ! (ngroup,ngroup,nx-1)
@@ -83,6 +84,9 @@ contains
             + 2 * xslib%mat(mthis)%diffusion(g)/dx(nx)
         case ('mirror')
           dia(g,g,nx) = dprev + xslib%mat(mthis)%sigma_t(g) * dx(nx)
+        case ('albedo')
+          dia(g,g,nx) = dprev + xslib%mat(mthis)%sigma_t(g) * dx(nx) &
+            + 1.0_rk / (1.0_rk / albedo_alpha + 0.5_rk * dx(nx) / xslib%mat(mthis)%diffusion(g))
         case default
           call exception_fatal(&
             'unknown boundary_right in diffusion_block_build_matrix: ' &
@@ -140,18 +144,20 @@ contains
   endfunction diffusion_block_fission_summation
 
   subroutine diffusion_block_power_iteration( &
-    nx, dx, mat_map, xslib, &
-    boundary_left, boundary_right, k_tol, phi_tol, max_iter, keff, flux)
+    nx, dx, mat_map, xslib, boundary_left, boundary_right, albedo_coeff, &
+    k_tol, phi_tol, max_iter, keff, flux)
     use xs, only : XSLibrary
     use linalg, only : trid_block
     use output, only : output_write
     use timer, only : timer_start, timer_stop
     use exception_handler, only : exception_warning
+    use albedo, only : albedo_calculate_alpha
     integer(ik), intent(in) :: nx
     real(rk), intent(in) :: dx(:) ! (nx)
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     type(XSLibrary), intent(in) :: xslib
     character(*), intent(in) :: boundary_left, boundary_right
+    real(rk), intent(in) :: albedo_coeff ! A \in [-1,1]
     real(rk), intent(in) :: k_tol, phi_tol
     integer(ik), intent(in) :: max_iter
     real(rk), intent(out) :: keff
@@ -161,6 +167,7 @@ contains
     integer(ik) :: i, g
     real(rk) :: fsum, fsum_old, k_old
     real(rk) :: delta_k, delta_phi
+    real(rk) :: albedo_alpha ! \alpha \in [0,\infty)
 
     ! (ngroup,ngroup,nx-1) , (nxgroup,ngroup,nx) , (ngroup,ngroup,nx-1)
     real(rk), allocatable :: sub(:,:,:), dia(:,:,:), sup(:,:,:)
@@ -182,9 +189,10 @@ contains
     allocate(sub_copy(xslib%ngroup,xslib%ngroup,nx-1), dia_copy(xslib%ngroup,xslib%ngroup,nx), &
       sup_copy(xslib%ngroup,xslib%ngroup,nx-1))
 
+    albedo_alpha = albedo_calculate_alpha(albedo_coeff)
     call timer_start('diffusion_build_matrix')
     call diffusion_block_build_matrix(nx, dx, mat_map, xslib, &
-      boundary_left, boundary_right, sub, dia, sup)
+      boundary_left, boundary_right, albedo_alpha, sub, dia, sup)
     call timer_stop('diffusion_build_matrix')
 
     allocate(fsource(xslib%ngroup,nx))

--- a/src/input.f90
+++ b/src/input.f90
@@ -8,7 +8,7 @@ private
 integer(ik) :: nx
 real(rk), allocatable :: dx(:)
 character(1024) :: xslib_fname, transient_fname
-integer(ik), allocatable :: mat_map(:)
+integer(ik), allocatable :: mat_map(:) ! (not input, populated later)
 character(16), allocatable :: mat_map_name(:)
 integer(ik) :: pnorder
 
@@ -19,6 +19,7 @@ integer(ik) :: refine = 0
 
 ! optional boundary conditions
 ! only allowed for very special problems
+! (allowed for diffusion problems)
 character(16) :: boundary_left = 'mirror', boundary_right = 'mirror'
 
 ! optional analytic reference solution
@@ -37,6 +38,19 @@ logical :: force_consistent_diffusion = .false.
 ! optional calculation type. either 'eigenvalue' or 'fixed_source'
 character(16) :: calc_type = 'eigenvalue'
 
+! Optional albedo factor.
+! Only a single albedo can be specified for the whole problem.
+! One value overall, not specified per-group or per-edge at the moment.
+! This is specified as a "big-A" albedo factor (rathern than an alpha as used in
+! LUPINE and DIF3D).
+!             |  A  |  alpha  |
+! ------------|-----|---------|
+!  zero-flux  | -1  | \infty  |
+!  "vacuum"   |  0  |  1/2    |
+!   mirror    |  1  |    0    |
+!
+real(rk) :: albedo_coeff = 0.0_rk
+
 public :: input_read, input_cleanup
 
 public :: nx, dx, xslib_fname, transient_fname, mat_map, mat_map_name
@@ -48,6 +62,7 @@ public :: analytic_reference
 public :: energy_solver_opt
 public :: high_low, force_consistent_diffusion
 public :: calc_type
+public :: albedo_coeff
 
 contains
 
@@ -115,6 +130,8 @@ contains
           read(iounit, *) card, boundary_left
         case ('boundary_right')
           read(iounit, *) card, boundary_right
+        case ('albedo')
+          read(iounit, *) card, albedo_coeff
         case ('analytic_reference')
           read(iounit, *) card, analytic_reference
         case ('energy_solver_opt')
@@ -156,12 +173,14 @@ contains
     call output_write('xslib_fname = "' // trim(adjustl(xslib_fname)) // '"')
     write(line, '(a,i0)') 'refine = ', refine
     call output_write(line)
-    write(line, '(a,es13.6)') 'k_tol = ', k_tol
+    write(line, '(a,es9.2)') 'k_tol = ', k_tol
     call output_write(line)
-    write(line, '(a,es13.6)') 'phi_tol = ', phi_tol
+    write(line, '(a,es9.2)') 'phi_tol = ', phi_tol
     call output_write(line)
     call output_write('boundary_left = *' // trim(adjustl(boundary_left)) // '*')
     call output_write('boundary_right = *' // trim(adjustl(boundary_right)) // '*')
+    write(line, '(a,es9.2)') 'albedo = ', albedo_coeff
+    call output_write(line)
     call output_write('analytic_reference = *' // trim(adjustl(analytic_reference)) // '*')
 
     call output_write('energy_solver_opt = *' // trim(adjustl(energy_solver_opt)) // '*')

--- a/src/input.f90
+++ b/src/input.f90
@@ -167,6 +167,7 @@ contains
 
   subroutine input_summary()
     use output, only : output_write
+    use albedo, only : albedo_calculate_alpha
     character(1024) :: line
 
     call output_write('=== INPUT ===')
@@ -179,7 +180,8 @@ contains
     call output_write(line)
     call output_write('boundary_left = *' // trim(adjustl(boundary_left)) // '*')
     call output_write('boundary_right = *' // trim(adjustl(boundary_right)) // '*')
-    write(line, '(a,es9.2)') 'albedo = ', albedo_coeff
+    write(line, '(a,es9.2,a,es9.2,a)') 'albedo = ', albedo_coeff, &
+      ' (alpha = ', albedo_calculate_alpha(albedo_coeff), ')'
     call output_write(line)
     call output_write('analytic_reference = *' // trim(adjustl(analytic_reference)) // '*')
 

--- a/src/linalg.f90
+++ b/src/linalg.f90
@@ -4,7 +4,7 @@ implicit none
 
 private
 
-public :: trid, norm, trid_block, inv, solve, geneig
+public :: trid, norm, trid_block, inv, solve, geneig, eye
 
 integer, parameter, private :: double_kind = kind(1d0)
 
@@ -220,5 +220,16 @@ contains
     deallocate(alphar, alphai)
     deallocate(acpy, bcpy)
   endsubroutine geneig
+
+  ! fill an identity matrix
+  subroutine eye(n, mat)
+    integer(ik), intent(in) :: n
+    real(rk), intent(out) :: mat(:,:) ! (n,n)
+    integer(ik) :: i
+    mat = 0.0_rk
+    do i = 1,n
+      mat(i,i) = 1.0_rk
+    enddo
+  endsubroutine eye
 
 endmodule linalg

--- a/src/main.f90
+++ b/src/main.f90
@@ -6,7 +6,7 @@ use input, only : input_read, input_cleanup, &
   refine, nx, dx, mat_map, mat_map_name, pnorder, &
   boundary_left, boundary_right, &
   k_tol, phi_tol, max_iter, analytic_reference, energy_solver_opt, &
-  high_low, force_consistent_diffusion, calc_type
+  high_low, force_consistent_diffusion, calc_type, albedo_coeff
 use geometry, only : geometry_uniform_refinement, geometry_summary
 use diffusion, only : diffusion_power_iteration
 use diffusion_block, only : diffusion_block_power_iteration
@@ -190,7 +190,8 @@ if (is_transient) then
 endif
 
 if (analytic_reference /= 'none') then
-  call analytic_error(analytic_reference, fname_analytic, nx, xs%ngroup, pnorder, xs, dx, phi, keff)
+  call analytic_error(analytic_reference, fname_analytic, &
+    nx, xs%ngroup, pnorder, xs, dx, phi, keff, albedo_coeff)
 endif
 
 call timer_start('output')

--- a/src/main.f90
+++ b/src/main.f90
@@ -149,7 +149,7 @@ if (pnorder == 0) then
         boundary_left, boundary_right, k_tol, phi_tol, max_iter, keff, phi(:,:,1))
     case ('onegroup')
       call diffusion_power_iteration( &
-        nx, dx, mat_map, xs, boundary_left, boundary_right, &
+        nx, dx, mat_map, xs, boundary_left, boundary_right, albedo_coeff, &
         k_tol, phi_tol, max_iter, keff, phi(:,:,1))
     case default
       call exception_fatal('unknown energy_solver_opt: ' // trim(adjustl(energy_solver_opt)))
@@ -163,7 +163,7 @@ else
         k_tol, phi_tol, max_iter, pnorder, keff, sigma_tr, phi)
       if (high_low) then
         call diffusion_power_iteration( &
-          nx, dx, mat_map, xs, boundary_left, boundary_right, &
+          nx, dx, mat_map, xs, boundary_left, boundary_right, albedo_coeff, &
           k_tol, phi_tol, max_iter, keff, phi(:,:,1), &
           transportxs = sigma_tr(:,:,2))
       endif
@@ -184,14 +184,14 @@ call output_write('')
 if (is_transient) then
   call timer_start('transient')
   call transient_solve(fname_stub, &
-    nx, dx, mat_map, xs, kindat, boundary_left, boundary_right, &
+    nx, dx, mat_map, xs, kindat, boundary_left, boundary_right, albedo_coeff, &
     phi_tol, max_iter, keff, phi(:,:,1))
   call timer_stop('transient')
 endif
 
 if (analytic_reference /= 'none') then
   call analytic_error(analytic_reference, fname_analytic, &
-    nx, xs%ngroup, pnorder, xs, dx, phi, keff, albedo_coeff)
+    nx, xs%ngroup, pnorder, xs, dx, phi, keff)
 endif
 
 call timer_start('output')

--- a/src/main.f90
+++ b/src/main.f90
@@ -145,8 +145,8 @@ if (pnorder == 0) then
   select case (energy_solver_opt)
     case ('block')
       call diffusion_block_power_iteration( &
-        nx, dx, mat_map, xs, &
-        boundary_left, boundary_right, k_tol, phi_tol, max_iter, keff, phi(:,:,1))
+        nx, dx, mat_map, xs, boundary_left, boundary_right, albedo_coeff, &
+        k_tol, phi_tol, max_iter, keff, phi(:,:,1))
     case ('onegroup')
       call diffusion_power_iteration( &
         nx, dx, mat_map, xs, boundary_left, boundary_right, albedo_coeff, &

--- a/src/transient.f90
+++ b/src/transient.f90
@@ -362,7 +362,8 @@ contains
   endsubroutine transient_build_diagonal
 
   subroutine transient_solve(fname_stub, nx, dx, mat_map, xs, dnd, &
-      boundary_left, boundary_right, phi_tol, max_iter, keff, flux)
+      boundary_left, boundary_right, albedo_coeff, &
+      phi_tol, max_iter, keff, flux)
     use xs, only : XSLibrary
     use output, only : output_write
     use power, only : power_calculate, power_total
@@ -371,6 +372,7 @@ contains
     use linalg, only : trid
     use fileio, only : fileio_open_write
     use output, only : output_power_csv, output_flux_csv
+    use albedo, only : albedo_calculate_alpha
     character(*), intent(in) :: fname_stub
     integer(ik), intent(in) :: nx
     real(rk), intent(in) :: dx(:) ! (nx)
@@ -378,6 +380,7 @@ contains
     type(XSLibrary), intent(in) :: xs
     type(DelayedNeutronData), intent(in) :: dnd
     character(*), intent(in) :: boundary_left, boundary_right
+    real(rk), intent(in) :: albedo_coeff ! A \in [-1,1]
     real(rk), intent(in) :: phi_tol
     integer(ik), intent(in) :: max_iter
     real(rk), intent(in) :: keff
@@ -399,6 +402,7 @@ contains
     integer(ik) :: step, iter, g, idx
     real(rk) :: tfinal
     real(rk) :: phi_conv
+    real(rk) :: albedo_alpha ! \alpha \in [0,\infty]
 
     character(1024) :: line
 
@@ -462,8 +466,10 @@ contains
 
     ! only the diagonal needs to be modified compared to steady-state solution
     ! the off-diagonal never change (if diffusion coeff never changes)
+    albedo_alpha = albedo_calculate_alpha(albedo_coeff)
     call diffusion_build_matrix(&
-      nx, dx, mat_map, xslib, boundary_left, boundary_right, sub, dia, sup)
+      nx, dx, mat_map, xslib, boundary_left, boundary_right, albedo_alpha, &
+      sub, dia, sup)
 
     ! edit requested before first step
     idx = 0

--- a/tools/analytic_plot.py
+++ b/tools/analytic_plot.py
@@ -2,6 +2,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 import sys
 
+import plot_settings
+
 if __name__ == "__main__":
 
     fname = sys.argv[1]


### PR DESCRIPTION
Supporting albedo boundary condition for diffusion solvers.

Also added an analytical benchmark. It required numerical solution for the buckling term (similar to the two-region problem).

Resolves #30 