### PR TITLE
Removing unnecessary matrix copies

### DIFF
--- a/src/diffusion.f90
+++ b/src/diffusion.f90
@@ -255,7 +255,7 @@ contains
     real(rk), intent(in), optional :: transportxs(:,:) ! (nx,ngroup)
 
     real(rk), allocatable :: sub(:,:), dia(:,:), sup(:,:)
-    real(rk), allocatable :: sub_copy(:), dia_copy(:), sup_copy(:)
+    real(rk), allocatable :: dia_copy(:)
     real(rk), allocatable :: fsource(:,:), upsource(:,:), downsource(:)
     real(rk), allocatable :: q(:)
 
@@ -273,7 +273,7 @@ contains
     logical, parameter :: matrix_dump = .false.
 
     allocate(sub(nx-1,xslib%ngroup), dia(nx,xslib%ngroup), sup(nx-1,xslib%ngroup))
-    allocate(sub_copy(nx-1), dia_copy(nx), sup_copy(nx-1))
+    allocate(dia_copy(nx))
 
     if (present(transportxs)) then
       allocate(diffusion_coeff(nx,xslib%ngroup))
@@ -333,10 +333,8 @@ contains
         call timer_start('diffusion_tridiagonal')
         ! SOLVE
         ! need to store copies, trid uses them as scratch space
-        sub_copy = sub(:,g)
         dia_copy = dia(:,g)
-        sup_copy = sup(:,g)
-        call trid(nx, sup_copy, dia_copy, sup_copy, q, flux(:,g))
+        call trid(nx, sub(:,g), dia_copy, sup(:,g), q, flux(:,g))
         call timer_stop('diffusion_tridiagonal')
 
       enddo
@@ -363,7 +361,7 @@ contains
 
     deallocate(flux_old)
     deallocate(sub, dia, sup)
-    deallocate(sub_copy, dia_copy, sup_copy)
+    deallocate(dia_copy)
     deallocate(fsource, upsource, downsource)
     deallocate(q)
     if (allocated(diffusion_coeff)) then

--- a/src/diffusion_block.f90
+++ b/src/diffusion_block.f90
@@ -174,7 +174,6 @@ contains
 
     ! (ngroup,ngroup,nx-1) , (nxgroup,ngroup,nx) , (ngroup,ngroup,nx-1)
     real(rk), allocatable :: sub(:,:,:), dia(:,:,:), sup(:,:,:)
-    real(rk), allocatable :: sub_copy(:,:,:), dia_copy(:,:,:), sup_copy(:,:,:)
 
     real(rk), allocatable :: fsource(:,:) ! (ngroup,nx)
 
@@ -189,8 +188,6 @@ contains
       dia(xslib%ngroup,xslib%ngroup,nx),&
       sup(xslib%ngroup,xslib%ngroup,nx-1)&
     )
-    allocate(sub_copy(xslib%ngroup,xslib%ngroup,nx-1), dia_copy(xslib%ngroup,xslib%ngroup,nx), &
-      sup_copy(xslib%ngroup,xslib%ngroup,nx-1))
 
     albedo_alpha = albedo_calculate_alpha(albedo_coeff)
     call timer_start('diffusion_build_matrix')
@@ -221,10 +218,7 @@ contains
       fsource = fsource / keff
 
       call timer_start('diffusion_block_tridiagonal')
-      sub_copy = sub
-      dia_copy = dia
-      sup_copy = sup
-      call trid_block(nx, xslib%ngroup, sub_copy, dia_copy, sup_copy, fsource, flux_block)
+      call trid_block(nx, xslib%ngroup, sub, dia, sup, fsource, flux_block)
       call timer_stop('diffusion_block_tridiagonal')
 
       fsum = diffusion_block_fission_summation(nx, dx, mat_map, xslib, flux_block)
@@ -257,7 +251,6 @@ contains
     enddo ! i = 1,nx
 
     deallocate(sub, dia, sup)
-    deallocate(sub_copy, dia_copy, sup_copy)
     deallocate(fsource)
     deallocate(flux_block, flux_old)
   endsubroutine diffusion_block_power_iteration

--- a/src/transport.f90
+++ b/src/transport.f90
@@ -549,7 +549,7 @@ contains
 
     ! matrix
     real(rk), allocatable :: sub(:,:,:), dia(:,:,:), sup(:,:,:) ! (nx, ngroup, neven)
-    real(rk), allocatable :: sub_copy(:), dia_copy(:), sup_copy(:)
+    real(rk), allocatable :: dia_copy(:)
     ! neutron source
     real(rk), allocatable :: fsource(:,:) ! (nx, ngroup) -- all p0
     real(rk), allocatable :: upsource(:,:) ! (nx, ngroup) -- just this moment
@@ -577,7 +577,7 @@ contains
     neven = max((pnorder + 1) / 2, 1)
 
     allocate(sub(nx-1,xslib%ngroup,neven), dia(nx,xslib%ngroup,neven), sup(nx-1,xslib%ngroup,neven))
-    allocate(sub_copy(nx-1), dia_copy(nx), sup_copy(nx-1))
+    allocate(dia_copy(nx))
 
     allocate(fsource(nx,xslib%ngroup))
     allocate(upsource(nx,xslib%ngroup))
@@ -657,10 +657,8 @@ contains
           call timer_start('transport_tridiagonal')
           ! SOLVE
           ! need to store copies, trid uses them as scratch space
-          sub_copy = sub(:,g,n)
           dia_copy = dia(:,g,n)
-          sup_copy = sup(:,g,n)
-          call trid(nx, sub_copy, dia_copy, sup_copy, q, phi(:,g,idxn+1))
+          call trid(nx, sub(:,g,n), dia_copy, sup(:,g,n), q, phi(:,g,idxn+1))
           call timer_stop('transport_tridiagonal')
 
         enddo ! g = 1,ngroup
@@ -705,7 +703,7 @@ contains
     endif
 
     deallocate(sub, dia, sup)
-    deallocate(sub_copy, dia_copy, sup_copy)
+    deallocate(dia_copy)
     deallocate(fsource, upsource, downsource, q)
     deallocate(pn_next_source, pn_prev_source)
     deallocate(phi_old)

--- a/src/transport_block.f90
+++ b/src/transport_block.f90
@@ -577,8 +577,6 @@ contains
 
     ! (ngroup,ngroup,nx-1,neven) , (ngroup,ngroup,nx,neven) , (ngroup,ngroup,nx-1,neven)
     real(rk), allocatable :: sub(:,:,:,:), dia(:,:,:,:), sup(:,:,:,:)
-    ! (ngroup,ngroup,nx-1) , (ngroup,ngroup,nx) , (ngroup,ngroup,nx-1)
-    real(rk), allocatable :: sub_copy(:,:,:), dia_copy(:,:,:), sup_copy(:,:,:)
 
     real(rk), allocatable :: fsource(:,:) ! (ngroup,nx)
     real(rk), allocatable :: pn_prev_source(:,:) ! (ngroup,nx) -- for this moment
@@ -597,9 +595,6 @@ contains
     allocate(sub(xslib%ngroup,xslib%ngroup,nx-1,neven),&
       dia(xslib%ngroup,xslib%ngroup,nx,neven),&
       sup(xslib%ngroup,xslib%ngroup,nx-1,neven))
-    allocate(sub_copy(xslib%ngroup,xslib%ngroup,nx-1),&
-      dia_copy(xslib%ngroup,xslib%ngroup,nx),&
-      sup_copy(xslib%ngroup,xslib%ngroup,nx-1))
 
     allocate(fsource(xslib%ngroup,nx))
     allocate(pn_prev_source(xslib%ngroup,nx))
@@ -679,11 +674,9 @@ contains
         endif
 
         call timer_start('transport_block_tridiagonal')
-        sub_copy = sub(:,:,:,n)
-        dia_copy = dia(:,:,:,n)
-        sup_copy = sup(:,:,:,n)
         call trid_block( &
-          nx, xslib%ngroup, sub_copy, dia_copy, sup_copy, q, phi_block(:,:,idxn+1))
+          nx, xslib%ngroup, sub(:,:,:,n), dia(:,:,:,n), sup(:,:,:,n), &
+          q, phi_block(:,:,idxn+1))
         call timer_stop('transport_block_tridiagonal')
       enddo ! n = 1,neven
 
@@ -739,7 +732,6 @@ contains
     deallocate(fsource, pn_prev_source, pn_next_source, q)
     deallocate(phi_block, phi_old)
     deallocate(sub, dia, sup)
-    deallocate(sub_copy, dia_copy, sup_copy)
   endsubroutine transport_block_power_iteration
 
   subroutine transport_block_calc_odd(nx, dx, mat_map, xslib, &


### PR DESCRIPTION
Resolves #37 

I saw that only the diagonal of the tri-diagonal matrix is actually "trampled" during the tri-diagonal algorithm in `trid`. Moreover, it turns out I handle internal copies inside of `trid_block` so *all* of the block copies were unnecessary!

This should really use a lot less memory! It may be worth trying to rerun some previous cases.