### PR TITLE
Add C-API for an albedo transient

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(siren VERSION 0.2.0 DESCRIPTION "A one-dimensional PN neutron transport solver." LANGUAGES Fortran)
+project(siren VERSION 0.2.0 DESCRIPTION "A one-dimensional PN neutron transport solver." LANGUAGES Fortran C)
 
 add_executable(${PROJECT_NAME}.x)
 
@@ -26,6 +26,7 @@ target_sources(${PROJECT_NAME}.x
     src/transport_block.f90
     src/transport.f90
     src/xs.f90
+    src/transient_albedo.c
 )
 
 find_package(OpenMP REQUIRED)
@@ -36,7 +37,9 @@ target_link_libraries(${PROJECT_NAME}.x LAPACK::LAPACK)
 
 # Note that the CMake language does not allow setting the Fortran_STANDARD from the build instructions
 # and it must be specified via the command-line argument.
-target_compile_options(${PROJECT_NAME}.x PRIVATE -Wall -Wextra -std=f2018 -pedantic)
-target_compile_options(${PROJECT_NAME}.x PRIVATE $<$<CONFIG:Debug>:-O0;-g;-fbacktrace;-ffpe-trap=invalid,overflow,zero;-fcheck=all>)
+target_compile_options(${PROJECT_NAME}.x PRIVATE $<$<COMPILE_LANGUAGE:Fortran>:-Wall;-Wextra;-std=f2018;-pedantic>)
+target_compile_options(${PROJECT_NAME}.x PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wall;-Wextra;-ansi;-pedantic>)
+target_compile_options(${PROJECT_NAME}.x PRIVATE $<$<AND:$<COMPILE_LANGUAGE:Fortran>,$<CONFIG:Debug>>:-fbacktrace;-ffpe-trap=invalid,overflow,zero;-fcheck=all>)
+target_compile_options(${PROJECT_NAME}.x PRIVATE $<$<CONFIG:Debug>:-O0;-g>)
 target_compile_options(${PROJECT_NAME}.x PRIVATE $<$<CONFIG:Release>:-O3>)
 target_compile_options(${PROJECT_NAME}.x PRIVATE $<$<CONFIG:>:-O3>) # include default/empty option

--- a/cases/transient/albedo_pid/albedo.kin
+++ b/cases/transient/albedo_pid/albedo.kin
@@ -7,5 +7,5 @@ vel 1e6
 
 deltat 1e-3
 tend 4.0
-reference 'albedo-pid'
+reference 'albedo-pid-capi'
 tedit 5 0.0 1.0 2.0 3.0 4.0

--- a/src/transient.f90
+++ b/src/transient.f90
@@ -2,6 +2,12 @@ module transient
 use kind, only : rk, ik
 implicit none
 
+interface
+  real(c_double) function transient_albedo() bind(C, name='transient_albedo')
+    use, intrinsic :: iso_c_binding, only : c_double
+  endfunction transient_albedo
+endinterface
+
 private
 
 type DelayedNeutronData
@@ -717,7 +723,7 @@ contains
   endfunction transient_albedo_pid
 
   real(rk) function transient_albedo_capi(time, albedo_coeff, pboundary)
-    use iso_c_binding, only : c_double
+    use, intrinsic :: iso_c_binding, only : c_double
     real(rk), intent(in) :: time
     real(rk), intent(in) :: albedo_coeff
     real(rk), intent(in) :: pboundary
@@ -731,8 +737,8 @@ contains
     c_albedo_coeff = real(albedo_coeff, c_double)
     c_pboundary = real(pboundary, c_double)
 
-    c_alb = 0.5_c_double
     ! c_alb = transient_albedo(c_time, c_albedo_coeff, c_pboundary)
+    c_alb = transient_albedo()
 
     transient_albedo_capi = real(c_alb, rk)
   endfunction transient_albedo_capi

--- a/src/transient.f90
+++ b/src/transient.f90
@@ -637,7 +637,7 @@ contains
         if (time <= 0.01_rk) then
           xs%mat(1)%sigma_t(2) = sigma0 - time/0.01_rk * 0.05_rk * sigma0
         endif
-      case ('albedo-pid')
+      case ('albedo-pid', 'albedo-pid-capi')
         if (first) then
           xs%mat(1)%sigma_t(1) = 0.99_rk * xs%mat(1)%sigma_t(1)
           first = .false.
@@ -666,6 +666,9 @@ contains
       case ('albedo-pid')
         transient_update_albedo = &
           transient_albedo_pid(time, albedo_coeff, pboundary)
+      case ('albedo-pid-capi')
+        transient_update_albedo = &
+          transient_albedo_capi(time, albedo_coeff, pboundary)
       case default
         transient_update_albedo = 0.0_rk
         call exception_fatal('Unknown transient albedo reference name: ' &
@@ -693,8 +696,7 @@ contains
     if (first) then
       p0 = pboundary
       transient_albedo_pid = albedo_coeff
-      prev_error = p0
-      prev_time = time
+      error = 0.0_rk
       interror = 0.0_rk
       first = .false.
     else
@@ -709,9 +711,30 @@ contains
       transient_albedo_pid = min(max(transient_albedo_pid, -1.0_rk), 1.0_rk)
       ! write(*,'(a,1x,es9.2,1x,a,1x,es9.2,1x,a,1x,es9.2)') &
       !   'error', error, 'albedo', transient_albedo_pid, 'pboundary', pboundary
-      prev_error = error
-      prev_time = time
     endif
+    prev_error = error
+    prev_time = time
   endfunction transient_albedo_pid
+
+  real(rk) function transient_albedo_capi(time, albedo_coeff, pboundary)
+    use iso_c_binding, only : c_double
+    real(rk), intent(in) :: time
+    real(rk), intent(in) :: albedo_coeff
+    real(rk), intent(in) :: pboundary
+
+    real(c_double) :: c_time
+    real(c_double) :: c_albedo_coeff
+    real(c_double) :: c_pboundary
+    real(c_double) :: c_alb
+
+    c_time = real(time, c_double)
+    c_albedo_coeff = real(albedo_coeff, c_double)
+    c_pboundary = real(pboundary, c_double)
+
+    c_alb = 0.5_c_double
+    ! c_alb = transient_albedo(c_time, c_albedo_coeff, c_pboundary)
+
+    transient_albedo_capi = real(c_alb, rk)
+  endfunction transient_albedo_capi
 
 endmodule transient

--- a/src/transient.f90
+++ b/src/transient.f90
@@ -3,8 +3,10 @@ use kind, only : rk, ik
 implicit none
 
 interface
-  real(c_double) function transient_albedo() bind(C, name='transient_albedo')
+  real(c_double) function transient_albedo(time, albedo_coeff, pboundary) &
+      bind(C, name='transient_albedo')
     use, intrinsic :: iso_c_binding, only : c_double
+    real(c_double), value, intent(in) :: time, albedo_coeff, pboundary
   endfunction transient_albedo
 endinterface
 
@@ -737,8 +739,7 @@ contains
     c_albedo_coeff = real(albedo_coeff, c_double)
     c_pboundary = real(pboundary, c_double)
 
-    ! c_alb = transient_albedo(c_time, c_albedo_coeff, c_pboundary)
-    c_alb = transient_albedo()
+    c_alb = transient_albedo(c_time, c_albedo_coeff, c_pboundary)
 
     transient_albedo_capi = real(c_alb, rk)
   endfunction transient_albedo_capi

--- a/src/transient_albedo.c
+++ b/src/transient_albedo.c
@@ -14,6 +14,7 @@ int first = 1;
 double max(const double a, const double b){ return (a > b) ? a : b; }
 double min(const double a, const double b){ return (a < b) ? a : b; }
 
+#if 0
 double transient_albedo(double time, double albedo_coeff, double pboundary)
 {
   double alb;
@@ -46,3 +47,6 @@ double transient_albedo(double time, double albedo_coeff, double pboundary)
 
   return alb;
 }
+#endif
+
+double transient_albedo(void){return 0.5;}

--- a/src/transient_albedo.c
+++ b/src/transient_albedo.c
@@ -1,9 +1,9 @@
 #include "transient_albedo.h"
 
-extern double p0;
-extern double prev_error;
-extern double prev_time;
-extern double interror;
+double p0;
+double prev_error;
+double prev_time;
+double interror;
 
 const double kp = 0.004;
 const double ki = 0.0;
@@ -14,7 +14,6 @@ int first = 1;
 double max(const double a, const double b){ return (a > b) ? a : b; }
 double min(const double a, const double b){ return (a < b) ? a : b; }
 
-#if 0
 double transient_albedo(double time, double albedo_coeff, double pboundary)
 {
   double alb;
@@ -47,6 +46,3 @@ double transient_albedo(double time, double albedo_coeff, double pboundary)
 
   return alb;
 }
-#endif
-
-double transient_albedo(void){return 0.5;}

--- a/src/transient_albedo.c
+++ b/src/transient_albedo.c
@@ -1,0 +1,48 @@
+#include "transient_albedo.h"
+
+extern double p0;
+extern double prev_error;
+extern double prev_time;
+extern double interror;
+
+const double kp = 0.004;
+const double ki = 0.0;
+const double kd = 0.001;
+
+int first = 1;
+
+double max(const double a, const double b){ return (a > b) ? a : b; }
+double min(const double a, const double b){ return (a < b) ? a : b; }
+
+double transient_albedo(double time, double albedo_coeff, double pboundary)
+{
+  double alb;
+  double dt;
+  double derror_dt;
+  double error;
+
+  alb = albedo_coeff;
+
+  if (first)
+  {
+    p0 = pboundary;
+    interror = 0.0;
+    error = 0.0;
+    first = 0;
+  }
+  else
+  {
+    error = p0 - pboundary;
+    dt = time - prev_time;
+    derror_dt = (error - prev_error) / dt;
+    interror += error * dt;
+    alb += kp * error + kd * derror_dt + ki * interror;
+    /* clamp */
+    alb = min(max(alb, -1.0), 1.0);
+  }
+
+  prev_time = time;
+  prev_error = error;
+
+  return alb;
+}

--- a/src/transient_albedo.h
+++ b/src/transient_albedo.h
@@ -15,10 +15,6 @@ extern int first;
 double max(const double a, const double b);
 double min(const double a, const double b);
 
-/*
 double transient_albedo(const double time, const double albedo_coeff, const double pboundary);
-*/
-
-double transient_albedo(void);
 
 #endif

--- a/src/transient_albedo.h
+++ b/src/transient_albedo.h
@@ -1,0 +1,20 @@
+#ifndef TRANSIENT_ALBEDO_H
+#define TRANSIENT_ALBEDO_H
+
+extern double p0;
+extern double prev_error;
+extern double prev_time;
+extern double interror;
+
+extern const double kp;
+extern const double ki;
+extern const double kd;
+
+extern int first;
+
+double max(const double a, const double b);
+double min(const double a, const double b);
+
+double transient_albedo(const double time, const double albedo_coeff, const double pboundary);
+
+#endif

--- a/src/transient_albedo.h
+++ b/src/transient_albedo.h
@@ -15,6 +15,10 @@ extern int first;
 double max(const double a, const double b);
 double min(const double a, const double b);
 
+/*
 double transient_albedo(const double time, const double albedo_coeff, const double pboundary);
+*/
+
+double transient_albedo(void);
 
 #endif


### PR DESCRIPTION
This is a very specialized case, but this API will be used to implement a boundary-control method using the albedo coefficient.

This does now require that the compilation environment also have access to a C compiler, but it is hard to imagine a Fortran compiler without a C compiler in modern times.

I have also required that the C-code be compiled to the ANSI standard. That is acceptable when I'm the only developer, but may be overly pedantic for others.

Resolves #32 