### PR TITLE
Add MMS Transient

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(${PROJECT_NAME}.x
     src/albedo.f90
     src/analytic.f90
     src/constant.f90
+    src/delayed_neutron_data.f90
     src/diffusion_block.f90
     src/diffusion.f90
     src/exception_handler.f90
@@ -23,6 +24,7 @@ target_sources(${PROJECT_NAME}.x
     src/power.f90
     src/timer.f90
     src/transient.f90
+    src/transient_mms.f90
     src/transport_block.f90
     src/transport.f90
     src/xs.f90

--- a/cases/doit_urrd.py
+++ b/cases/doit_urrd.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 import re
 
+
 def set_input(txt, pnorder, refine):
     out = []
     for line in txt:
@@ -74,4 +75,11 @@ if __name__ == "__main__":
 
     for c in keff:
         stub = re.sub("^.*/", "", c).replace(".inp", "")
-        print(stub + " & " + " {:.6f}".format(keff[c]) + " & " + "{:.2f}".format((1.0-keff[c])*1e5) + " \\\\")
+        print(
+            stub
+            + " & "
+            + " {:.6f}".format(keff[c])
+            + " & "
+            + "{:.2f}".format((1.0 - keff[c]) * 1e5)
+            + " \\\\"
+        )

--- a/cases/transient/mms/mms.inp
+++ b/cases/transient/mms/mms.inp
@@ -1,0 +1,14 @@
+xslib_fname mms.xs
+transient_fname mms.kin
+
+nx 10
+dx 10. 10. 10. 10. 10. 10. 10. 10. 10. 10.
+mat_map FUEL FUEL FUEL FUEL FUEL FUEL FUEL FUEL FUEL FUEL
+refine 7
+boundary_left zero
+boundary_right zero
+k_tol 1e-10
+phi_tol 1e-10
+max_iter 10000
+pnorder 0
+analytic_reference onegroup

--- a/cases/transient/mms/mms.inp
+++ b/cases/transient/mms/mms.inp
@@ -4,7 +4,7 @@ transient_fname mms.kin
 nx 10
 dx 10. 10. 10. 10. 10. 10. 10. 10. 10. 10.
 mat_map FUEL FUEL FUEL FUEL FUEL FUEL FUEL FUEL FUEL FUEL
-refine 7
+refine 5
 boundary_left zero
 boundary_right zero
 k_tol 1e-10

--- a/cases/transient/mms/mms.inp
+++ b/cases/transient/mms/mms.inp
@@ -9,6 +9,6 @@ boundary_left zero
 boundary_right zero
 k_tol 1e-10
 phi_tol 1e-10
-max_iter 10000
+max_iter 100000
 pnorder 0
 analytic_reference onegroup

--- a/cases/transient/mms/mms.kin
+++ b/cases/transient/mms/mms.kin
@@ -7,5 +7,6 @@ vel 1e7
 
 deltat 10e-3
 tend 1.0
-# TODO
-reference 'null'
+reference 'mms'
+
+tedit 5 0.0 0.25 0.50 0.75 1.00

--- a/cases/transient/mms/mms.kin
+++ b/cases/transient/mms/mms.kin
@@ -5,7 +5,7 @@ lambda 0.08
 ng 1
 vel 1e7
 
-deltat 10e-3
+deltat 0.625e-3
 tend 1.0
 reference 'mms'
 

--- a/cases/transient/mms/mms.kin
+++ b/cases/transient/mms/mms.kin
@@ -1,0 +1,11 @@
+nd 1
+beta 0.0075
+lambda 0.08
+
+ng 1
+vel 1e7
+
+deltat 10e-3
+tend 1.0
+# TODO
+reference 'null'

--- a/cases/transient/mms/mms.xs
+++ b/cases/transient/mms/mms.xs
@@ -1,0 +1,15 @@
+ngroup 1
+niso 1
+nmoment 1
+
+name FUEL
+diffusion
+0.05
+sigma_t
+0.153
+nusf
+0.156
+scatter 0
+0.0
+chi
+1.0

--- a/cases/transient/mms/plot_flux.py
+++ b/cases/transient/mms/plot_flux.py
@@ -1,0 +1,26 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+if __name__ == "__main__":
+
+    extension = "png"
+    resolution = 600
+
+    flux = []
+    for i in range(5):
+        dat = np.loadtxt("mms_flux_t{:d}.csv".format(i + 1), delimiter=",", skiprows=1)
+        x = dat[:, 0]
+        flux.append(dat[:, 1])
+
+    tedit = [0.0, 0.25, 0.5, 0.75, 1.0]
+    plt.figure()
+    for i in range(5):
+        plt.plot(x, flux[i], label="t={:.2f}s".format(tedit[i]))
+    plt.legend()
+    plt.xlabel("x [cm]")
+    plt.ylabel("Flux [arb. units]")
+    plt.title("Thermal Flux During Transient")
+    plt.tight_layout()
+    plt.savefig("flux." + extension, dpi=resolution)
+
+    plt.show()

--- a/cases/transient/mms/transient_plot.py
+++ b/cases/transient/mms/transient_plot.py
@@ -1,0 +1,50 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import sys
+
+# import plot_settings
+import matplotlib
+
+matplotlib.rcParams["lines.linewidth"] = 2
+matplotlib.rcParams["mathtext.fontset"] = "stix"
+matplotlib.rcParams["font.family"] = "STIXGeneral"
+matplotlib.rcParams["font.size"] = 14
+
+L = 100.0
+alpha = 1e9
+kappa_nu = 1.5e-11
+nusf = 0.156
+kappasf = kappa_nu * nusf
+p0 = 1e-3
+integral = 163.0 / 225.0 * L
+phi0 = p0 / kappasf * np.pi * 0.5 / L
+
+
+def relpow_exact(t):
+    return 1.0 + np.pi * alpha * integral * 0.5 / L / phi0 * t**2
+
+
+if __name__ == "__main__":
+
+    # fname = sys.argv[1]
+    fname = "mms_transient.csv"
+
+    extension = "png"
+    dpi = 600
+
+    dat = np.loadtxt(fname, delimiter=",", skiprows=1)
+
+    elapt = dat[:, 0]
+    relpow = dat[:, 2]
+
+    plt.figure()
+    plt.plot(elapt, relpow_exact(elapt), label="Exact")
+    plt.plot(elapt, relpow, label="Siren")
+    plt.legend()
+    plt.xlabel("Time [s]")
+    plt.ylabel("Relative Power [-]")
+    plt.title("Siren Transient")
+    plt.tight_layout()
+    plt.savefig("transient." + extension, dpi=600)
+
+    plt.show()

--- a/src/delayed_neutron_data.f90
+++ b/src/delayed_neutron_data.f90
@@ -1,0 +1,27 @@
+module delayed_neutron_data
+use kind, only : rk, ik
+implicit none
+
+private
+
+type DelayedNeutronData
+
+  integer(ik) :: nd ! number of delayed neutron precursor families
+  real(rk), allocatable :: beta(:) ! (nd) [-] Delayed neutron fractions
+  real(rk), allocatable :: lamd(:) ! (nd) [1/s] Delayed neutron decay constants
+
+  integer(ik) :: ng ! number of energy groups (for velocities)
+  real(rk), allocatable :: vel(:) ! (ng) [cm/s] Neutron velocity
+
+  real(rk) :: deltat ! [s] time-step size
+  real(rk) :: tend ! [s] final time
+
+  character(16) :: reference ! reference case (used to specify absorption xs)
+
+  integer(ik) :: ntime = 0
+  real(rk), allocatable :: tedit(:)
+endtype
+
+public :: DelayedNeutronData
+
+endmodule delayed_neutron_data

--- a/src/main.f90
+++ b/src/main.f90
@@ -21,8 +21,9 @@ use exception_handler, only : exception_fatal, exception_summary
 use timer, only : timer_init, timer_start, timer_stop, timer_summary
 use fileio, only : fileio_open_read
 use material, only : material_idx_from_name
-use transient, only : DelayedNeutronData, &
-  transient_read, transient_summary, transient_solve, transient_cleanup
+use transient, only : transient_read, transient_summary, transient_solve, transient_cleanup
+use delayed_neutron_data, only : DelayedNeutronData
+use transient_mms, only : transient_mms_init, transient_mms_cleanup
 implicit none
 
 integer, parameter :: input_file_unit = 15
@@ -99,6 +100,10 @@ if (is_transient) then
 
   call transient_read(transient_fname, kindat)
   call transient_summary(kindat)
+
+  if (kindat%reference == 'mms') then
+    call transient_mms_init(xs, kindat)
+  endif
 
   if (kindat%ng /= xs%ngroup) then
     call exception_fatal('Inconsistent number of energy groups in ' &
@@ -235,6 +240,9 @@ call xs_cleanup(xs)
 call input_cleanup()
 if (is_transient) then
   call transient_cleanup(kindat)
+  if (kindat%reference == 'mms') then
+    call transient_mms_cleanup()
+  endif
 endif
 
 call output_write('Normal Termination :)')

--- a/src/transient.f90
+++ b/src/transient.f90
@@ -12,25 +12,6 @@ endinterface
 
 private
 
-type DelayedNeutronData
-
-  integer(ik) :: nd ! number of delayed neutron precursor families
-  real(rk), allocatable :: beta(:) ! (nd) [-] Delayed neutron fractions
-  real(rk), allocatable :: lamd(:) ! (nd) [1/s] Delayed neutron decay constants
-
-  integer(ik) :: ng ! number of energy groups (for velocities)
-  real(rk), allocatable :: vel(:) ! (ng) [cm/s] Neutron velocity
-
-  real(rk) :: deltat ! [s] time-step size
-  real(rk) :: tend ! [s] final time
-
-  character(16) :: reference ! reference case (used to specify absorption xs)
-
-  integer(ik) :: ntime = 0
-  real(rk), allocatable :: tedit(:)
-endtype
-
-public :: DelayedNeutronData
 public :: transient_read, transient_summary, transient_solve, transient_cleanup
 
 contains
@@ -38,6 +19,7 @@ contains
   subroutine transient_read(fname, dnd)
     use fileio, only : fileio_open_read
     use exception_handler, only : exception_fatal
+    use delayed_neutron_data, only : DelayedNeutronData
     character(*), intent(in) :: fname
     type(DelayedNeutronData), intent(out) :: dnd
 
@@ -107,6 +89,7 @@ contains
 
   subroutine transient_summary(dnd)
     use output, only : output_write
+    use delayed_neutron_data, only : DelayedNeutronData
     type(DelayedNeutronData), intent(in) :: dnd
 
     character(2**16) :: line, tmp
@@ -164,6 +147,7 @@ contains
 
   subroutine transient_init_precursors(nx, mat_map, xslib, dnd, kcrit, flux, prec)
     use xs, only : XSLibrary
+    use delayed_neutron_data, only : DelayedNeutronData
     integer(ik), intent(in) :: nx
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     type(XSLibrary), intent(in) :: xslib
@@ -189,6 +173,7 @@ contains
   subroutine transient_update_precursors(nx, mat_map, xslib, dnd, kcrit, flux, &
     prec_old, prec)
     use xs, only : XSLibrary
+    use delayed_neutron_data, only : DelayedNeutronData
     integer(ik), intent(in) :: nx
     integer(ik), intent(in) :: mat_map(:) ! (nx)
     type(XSLibrary), intent(in) :: xslib
@@ -215,6 +200,7 @@ contains
 
   subroutine transient_build_kinsrc(nx, dx, mat_map, xslib, dnd, flux, prec, kinsrc)
     use xs, only : XSLibrary
+    use delayed_neutron_data, only : DelayedNeutronData
     integer(ik), intent(in) :: nx
     real(rk), intent(in) :: dx(:) ! (nx)
     integer(ik), intent(in) :: mat_map(:) ! (nx)
@@ -240,6 +226,7 @@ contains
 
   subroutine transient_build_fsource(nx, dx, mat_map, xslib, dnd, flux, fsrc)
     use xs, only : XSLibrary
+    use delayed_neutron_data, only : DelayedNeutronData
     integer(ik), intent(in) :: nx
     real(rk), intent(in) :: dx(:) ! (nx)
     integer(ik), intent(in) :: mat_map(:) ! (nx)
@@ -274,9 +261,11 @@ contains
   endsubroutine transient_build_fsource
 
   subroutine transient_build_diagonal(nx, dx, mat_map, xslib, dnd, &
-      boundary_left, boundary_right, albedo_alpha, dia)
+      boundary_left, boundary_right, albedo_alpha, time, dia)
     use xs, only : XSLibrary
     use exception_handler, only : exception_fatal
+    use delayed_neutron_data, only : DelayedNeutronData
+    use transient_mms, only : transient_mms_sigma_a
     integer(ik), intent(in) :: nx
     real(rk), intent(in) :: dx(:) ! (nx)
     integer(ik), intent(in) :: mat_map(:) ! (nx)
@@ -284,11 +273,13 @@ contains
     type(DelayedNeutronData), intent(in) :: dnd
     character(*), intent(in) :: boundary_left, boundary_right
     real(rk), intent(in) :: albedo_alpha
+    real(rk), intent(in) :: time
     real(rk), intent(out) :: dia(:,:) ! (nx,ngroup)
 
     integer(ik) :: i, g
     integer(ik) :: mprev, mthis, mnext
     real(rk) :: dprev, dnext
+    real(rk) :: xt, xleft
 
     ! BC at x=0, i=1
     mthis = mat_map(1)
@@ -297,19 +288,25 @@ contains
       dnext = 2 &
         * (xslib%mat(mthis)%diffusion(g) / dx(1) * xslib%mat(mnext)%diffusion(g) / dx(2)) &
         / (xslib%mat(mthis)%diffusion(g) / dx(1) + xslib%mat(mnext)%diffusion(g) / dx(2))
+      if (dnd%reference == 'mms') then
+        xt = transient_mms_sigma_a(0.5_rk * dx(1), time) &
+          + xslib%mat(mthis)%scatter(g,g,1)
+      else
+        xt = xslib%mat(mthis)%sigma_t(g)
+      endif
       select case (boundary_left)
         case ('zero')
           dia(1,g) = dnext &
-            + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(1) &
+            + (xt - xslib%mat(mthis)%scatter(g,g,1)) * dx(1) &
             + (1.0_rk / (dnd%vel(g) * dnd%deltat)) * dx(1) &
             + 2 * xslib%mat(mthis)%diffusion(g) / dx(1)
         case ('mirror')
           dia(1,g) = dnext &
-            + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(1) &
+            + (xt - xslib%mat(mthis)%scatter(g,g,1)) * dx(1) &
             + (1.0_rk / (dnd%vel(g) * dnd%deltat)) * dx(1)
         case ('albedo')
           dia(1,g) = dnext &
-            + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(1) &
+            + (xt - xslib%mat(mthis)%scatter(g,g,1)) * dx(1) &
             + (1.0_rk / (dnd%vel(g) * dnd%deltat)) * dx(1) &
             + 1.0_rk / (1.0_rk / albedo_alpha + 0.5_rk * dx(1) / xslib%mat(mthis)%diffusion(g))
         case default
@@ -320,6 +317,7 @@ contains
     enddo ! g = 1,xslib%ngroup
 
     do g = 1,xslib%ngroup
+      xleft = dx(1)
       do i = 2,nx-1
 
         mprev = mat_map(i-1)
@@ -333,8 +331,16 @@ contains
           * (xslib%mat(mthis)%diffusion(g) / dx(i) * xslib%mat(mnext)%diffusion(g) / dx(i+1)) &
           / (xslib%mat(mthis)%diffusion(g) / dx(i) + xslib%mat(mnext)%diffusion(g) / dx(i+1))
 
+        if (dnd%reference == 'mms') then
+          xt = transient_mms_sigma_a(xleft + 0.5_rk * dx(i), time) &
+            + xslib%mat(mthis)%scatter(g,g,1)
+          xleft = xleft + dx(i)
+        else
+          xt = xslib%mat(mthis)%sigma_t(g)
+        endif
+
         dia(i,g) = dprev + dnext &
-          + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(i) &
+          + (xt - xslib%mat(mthis)%scatter(g,g,1)) * dx(i) &
           + (1.0_rk / (dnd%vel(g) * dnd%deltat)) * dx(i)
 
       enddo ! i = 2,nx-1
@@ -347,19 +353,25 @@ contains
       dprev = 2 &
         * (xslib%mat(mthis)%diffusion(g) / dx(nx) * xslib%mat(mprev)%diffusion(g) / dx(nx-1)) &
         / (xslib%mat(mthis)%diffusion(g) / dx(nx) + xslib%mat(mprev)%diffusion(g) / dx(nx-1))
+      if (dnd%reference == 'mms') then
+        xt = transient_mms_sigma_a(sum(dx(1:nx-1)) + 0.5_rk*dx(nx), time) &
+          + xslib%mat(mthis)%scatter(g,g,1)
+      else
+        xt = xslib%mat(mthis)%sigma_t(g)
+      endif
       select case (boundary_right)
         case ('zero')
           dia(nx,g) = dprev &
-            + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(nx) &
+            + (xt - xslib%mat(mthis)%scatter(g,g,1)) * dx(nx) &
             + (1.0_rk / (dnd%vel(g) * dnd%deltat)) * dx(nx) &
             + 2 * xslib%mat(mthis)%diffusion(g) / dx(nx)
         case ('mirror')
           dia(nx,g) = dprev &
-            + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(nx) &
+            + (xt - xslib%mat(mthis)%scatter(g,g,1)) * dx(nx) &
             + (1.0_rk / (dnd%vel(g) * dnd%deltat)) * dx(nx)
         case ('albedo')
           dia(nx,g) = dprev &
-            + (xslib%mat(mthis)%sigma_t(g) - xslib%mat(mthis)%scatter(g,g,1)) * dx(nx) &
+            + (xt - xslib%mat(mthis)%scatter(g,g,1)) * dx(nx) &
             + (1.0_rk / (dnd%vel(g) * dnd%deltat)) * dx(nx) &
             + 1.0_rk / (1.0_rk / albedo_alpha + 0.5_rk * dx(nx) / xslib%mat(mthis)%diffusion(g))
         case default
@@ -382,6 +394,8 @@ contains
     use fileio, only : fileio_open_write
     use output, only : output_power_csv, output_flux_csv
     use albedo, only : albedo_calculate_alpha
+    use delayed_neutron_data, only : DelayedNeutronData
+    use exception_handler, only : exception_fatal
     character(*), intent(in) :: fname_stub
     integer(ik), intent(in) :: nx
     real(rk), intent(in) :: dx(:) ! (nx)
@@ -527,7 +541,7 @@ contains
       call transient_update_xs(dnd%reference, tfinal, xslib)
       call transient_build_diagonal(&
         nx, dx, mat_map, xslib, dnd, &
-        boundary_left, boundary_right, albedo_alpha, dia)
+        boundary_left, boundary_right, albedo_alpha, tfinal, dia)
 
       ! iterative scheme is necesary for one-group at-a-time problem
       do iter = 1,max_iter
@@ -558,6 +572,10 @@ contains
           exit
         endif
       enddo ! iter = 1,max_iter
+
+      if (iter > max_iter) then
+        call exception_fatal('Maximum iterations exceeded.')
+      endif
 
       call power_calculate(nx, mat_map, xslib, flux, power)
       write(line, '(es13.6, " , ", es13.6, " , ", es13.6)') &
@@ -598,6 +616,7 @@ contains
   endsubroutine transient_solve
 
   subroutine transient_cleanup(dnd)
+    use delayed_neutron_data, only : DelayedNeutronData
     type(DelayedNeutronData), intent(out) :: dnd
     if (allocated(dnd%beta)) then
       deallocate(dnd%beta)
@@ -650,6 +669,9 @@ contains
           xs%mat(1)%sigma_t(1) = 0.99_rk * xs%mat(1)%sigma_t(1)
           first = .false.
         endif
+      case ('mms')
+        ! do nothing here
+        ! this is handled in transient_build_diagonal
       case ('null', 'albedo')
         ! do nothing
       case default
@@ -665,7 +687,9 @@ contains
     real(rk), intent(in) :: albedo_coeff
     real(rk), intent(in) :: pboundary
     select case (name)
-      case ('null', 'anl-slab-6-a1', 'anl-slab-6-a2', 'anl-slab-6-a3', 'anl-slab-6-a4')
+      case ('null', &
+          'anl-slab-6-a1', 'anl-slab-6-a2', 'anl-slab-6-a3', 'anl-slab-6-a4', &
+          'mms')
         ! do nothing
         ! transparent pass-through
         transient_update_albedo = albedo_coeff

--- a/src/transient_mms.f90
+++ b/src/transient_mms.f90
@@ -1,0 +1,121 @@
+module transient_mms
+use kind, only : rk, ik
+use constant, only : pi
+use delayed_neutron_data, only : DelayedNeutronData
+use xs, only : XSLibrary
+implicit none
+
+private
+
+real(rk), parameter :: mms_L = 100.0_rk ! [cm] -- slab_length
+real(rk), parameter :: mms_p0 = 1e-3_rk ! [W/cm^2] -- initial power
+real(rk), parameter :: mms_coeff_a = -1184.0_rk/15.0_rk /mms_L**4
+real(rk), parameter :: mms_coeff_b =  2368.0_rk/15.0_rk /mms_L**3
+real(rk), parameter :: mms_coeff_c = -1486.0_rk/15.0_rk /mms_L**2
+real(rk), parameter :: mms_coeff_d =   302.0_rk/15.0_rk /mms_L
+real(rk), parameter :: mms_coeff_e = 0.0_rk
+real(rk), parameter :: mms_coeff_fint = 163d0/225d0 * mms_L
+real(rk), parameter :: mms_nusf = 0.156_rk
+real(rk), parameter :: mms_kappa_nu = 1.5e-11_rk
+real(rk), parameter :: mms_kappasf = mms_kappa_nu * mms_nusf ! NOTE: hard-wired...
+real(rk), parameter :: mms_phi0 = mms_p0/mms_kappasf * pi*0.5d0/mms_L
+real(rk), parameter :: mms_alpha = 1d9
+
+public :: transient_mms_init, transient_mms_cleanup
+public :: transient_mms_sigma_a
+
+type(DelayedNeutronData) :: kin
+type(XSLibrary) :: xslib
+
+contains
+
+  subroutine transient_mms_init(xs, dnd)
+    type(XSLibrary), intent(in) :: xs
+    type(DelayedNeutronData), intent(in) :: dnd
+    kin = dnd
+    xslib = xs
+  endsubroutine transient_mms_init
+
+  subroutine transient_mms_cleanup()
+    if (allocated(kin%beta)) then
+      deallocate(kin%beta)
+    endif
+    if (allocated(kin%lamd)) then
+      deallocate(kin%lamd)
+    endif
+    if (allocated(kin%vel)) then
+      deallocate(kin%vel)
+    endif
+    if (allocated(xslib%mat)) then
+      deallocate(xslib%mat)
+    endif
+  endsubroutine transient_mms_cleanup
+
+  real(rk) pure function transient_mms_f(x)
+    real(rk), intent(in) :: x
+    transient_mms_f = mms_coeff_a*x**4 + mms_coeff_b*x**3 + mms_coeff_c*x**2 &
+      + mms_coeff_d*x + mms_coeff_e
+  endfunction transient_mms_f
+
+  real(rk) pure function transient_mms_d2f_dx2(x)
+    real(rk), intent(in) :: x
+    transient_mms_d2f_dx2 = &
+      12.0_rk*mms_coeff_a*x**2 + 6.0_rk*mms_coeff_b*x + 2.0_rk*mms_coeff_c
+  endfunction transient_mms_d2f_dx2
+
+  real(rk) pure function transient_mms_phi(x, t)
+    real(rk), intent(in) :: x, t
+    transient_mms_phi = mms_phi0 * sin(pi * x / mms_L) &
+      + mms_alpha * t**2 * transient_mms_f(x)
+  endfunction transient_mms_phi
+
+  real(rk) pure function transient_mms_dphi_dt(x, t)
+    real(rk), intent(in) :: x, t
+    transient_mms_dphi_dt = 2.0_rk * mms_alpha * t * transient_mms_f(x)
+  endfunction transient_mms_dphi_dt
+
+  real(rk) pure function transient_mms_d2phi_dx2(x, t)
+    real(rk), intent(in) :: x, t
+    transient_mms_d2phi_dx2 = -mms_phi0 * (pi/mms_L)**2 * sin(pi*x/mms_L) &
+      + mms_alpha * t**2 * transient_mms_d2f_dx2(x)
+  endfunction transient_mms_d2phi_dx2
+
+  real(rk) function transient_mms_kcrit()
+    transient_mms_kcrit = xslib%mat(1)%nusf(1) &
+      / (xslib%mat(1)%diffusion(1)*(pi/mms_L)**2 &
+      + (xslib%mat(1)%sigma_t(1) - xslib%mat(1)%scatter(1,1,1)))
+  endfunction transient_mms_kcrit
+
+  real(rk) function transient_mms_c0(x)
+    real(rk), intent(in) :: x
+    transient_mms_c0 = kin%beta(1)/kin%lamd(1) &
+      * xslib%mat(1)%nusf(1)/transient_mms_kcrit() * mms_phi0 * sin(pi*x/mms_L)
+  endfunction transient_mms_c0
+
+  real(rk) function transient_mms_c(x, t)
+    real(rk), intent(in) :: x, t
+    transient_mms_c = kin%beta(1) * xslib%mat(1)%nusf(1)/transient_mms_kcrit() * ( &
+      mms_phi0 * sin(pi*x/mms_L) * (1.0_rk - exp(-kin%lamd(1)*t)) / kin%lamd(1) &
+      + mms_alpha * transient_mms_f(x) &
+      * (t**2 * kin%lamd(1)**2 - 2.0_rk * kin%lamd(1) * t + 2.0_rk - 2.0_rk * exp(-kin%lamd(1)*t)) &
+      / kin%lamd(1)**3 &
+      ) + exp(-kin%lamd(1)*t) * transient_mms_c0(x)
+  endfunction transient_mms_c
+
+  real(rk) function transient_mms_sigma_a(x, t)
+    real(rk), intent(in) :: x, t
+    transient_mms_sigma_a = ( &
+      xslib%mat(1)%nusf(1)/transient_mms_kcrit() * (1.0_rk - kin%beta(1)) * transient_mms_phi(x, t) &
+      + kin%lamd(1) * transient_mms_c(x, t) &
+      - transient_mms_dphi_dt(x, t) / kin%vel(1) &
+      + xslib%mat(1)%diffusion(1) * transient_mms_d2phi_dx2(x, t) &
+      ) / transient_mms_phi(x, t)
+    if (transient_mms_sigma_a < 0d0) then
+      write(*,'(a,es23.16)') 'x=', x
+      write(*,'(a,es23.16)') 't=', t
+      write(*,'(a,es23.16)') 'mms_sigma_a=', transient_mms_sigma_a
+      stop 'negative xs in mms_sigma_a'
+    endif
+  endfunction transient_mms_sigma_a
+
+endmodule transient_mms

--- a/src/transient_mms.f90
+++ b/src/transient_mms.f90
@@ -14,18 +14,19 @@ real(rk), parameter :: mms_coeff_b =  2368.0_rk/15.0_rk /mms_L**3
 real(rk), parameter :: mms_coeff_c = -1486.0_rk/15.0_rk /mms_L**2
 real(rk), parameter :: mms_coeff_d =   302.0_rk/15.0_rk /mms_L
 real(rk), parameter :: mms_coeff_e = 0.0_rk
-real(rk), parameter :: mms_coeff_fint = 163d0/225d0 * mms_L
+real(rk), parameter :: mms_coeff_fint = 163.0_rk/225.0_rk * mms_L
 real(rk), parameter :: mms_nusf = 0.156_rk
 real(rk), parameter :: mms_kappa_nu = 1.5e-11_rk
 real(rk), parameter :: mms_kappasf = mms_kappa_nu * mms_nusf ! NOTE: hard-wired...
 real(rk), parameter :: mms_phi0 = mms_p0/mms_kappasf * pi*0.5d0/mms_L
-real(rk), parameter :: mms_alpha = 1d9
+real(rk), parameter :: mms_alpha = 1e9_rk
 
 public :: transient_mms_init, transient_mms_cleanup
 public :: transient_mms_sigma_a
 
 type(DelayedNeutronData) :: kin
 type(XSLibrary) :: xslib
+logical :: mms_negative_flag = .false.
 
 contains
 
@@ -34,6 +35,7 @@ contains
     type(DelayedNeutronData), intent(in) :: dnd
     kin = dnd
     xslib = xs
+    mms_negative_flag = .false.
   endsubroutine transient_mms_init
 
   subroutine transient_mms_cleanup()
@@ -103,6 +105,7 @@ contains
   endfunction transient_mms_c
 
   real(rk) function transient_mms_sigma_a(x, t)
+    use exception_handler, only : exception_warning
     real(rk), intent(in) :: x, t
     transient_mms_sigma_a = ( &
       xslib%mat(1)%nusf(1)/transient_mms_kcrit() * (1.0_rk - kin%beta(1)) * transient_mms_phi(x, t) &
@@ -110,11 +113,11 @@ contains
       - transient_mms_dphi_dt(x, t) / kin%vel(1) &
       + xslib%mat(1)%diffusion(1) * transient_mms_d2phi_dx2(x, t) &
       ) / transient_mms_phi(x, t)
-    if (transient_mms_sigma_a < 0d0) then
-      write(*,'(a,es23.16)') 'x=', x
-      write(*,'(a,es23.16)') 't=', t
-      write(*,'(a,es23.16)') 'mms_sigma_a=', transient_mms_sigma_a
-      stop 'negative xs in mms_sigma_a'
+    if ((transient_mms_sigma_a < 0d0) .and. (.not. mms_negative_flag)) then
+      call exception_warning(&
+        'A negative value of sigma_a has been encountered ' &
+        // ' in the MMS calculation.')
+      mms_negative_flag = .true.
     endif
   endfunction transient_mms_sigma_a
 


### PR DESCRIPTION
Add a case solving the MMS transient from my earlier work.

This required splitting the `DelayedNeutronData` datatype into its own module so that it could be used in both `transient.f90` and `transient_mms.f90`.

Resolves #29 